### PR TITLE
Add the inline source support.

### DIFF
--- a/debug/embedded.html
+++ b/debug/embedded.html
@@ -52,7 +52,7 @@
                 sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <kicanvas-embed>
-                <kicanvas-source type="sch">
+                <kicanvas-source>
                     (kicad_sch (version 20230121) (generator eeschema) (uuid
                     5d5ad125-5ef1-42a1-a410-a0c4ab262ca6) (paper "A4")
                     (title_block (title "KiCanvas inline sources test") (date

--- a/debug/embedded.html
+++ b/debug/embedded.html
@@ -51,6 +51,18 @@
                 nulla pariatur. Excepteur sint occaecat cupidatat non proident,
                 sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
+            <kicanvas-embed>
+                <kicanvas-source extname="kicad_sch">
+                    (kicad_sch (version 20230121) (generator eeschema) (uuid
+                    5d5ad125-5ef1-42a1-a410-a0c4ab262ca6) (paper "A4")
+                    (title_block (title "KiCanvas inline sources test") (date
+                    "2023-11-10") ) (lib_symbols ) (text "KiCanvas inline
+                    sources test" (at 93.98 104.14 0) (effects (font (size 5 5)
+                    (thickness 1) bold) (justify left bottom)) (uuid
+                    27eb63d7-7111-4c0e-9985-c1ed90138e31) ) (sheet_instances
+                    (path "/" (page "1")) ) )
+                </kicanvas-source>
+            </kicanvas-embed>
         </main>
     </body>
 

--- a/debug/embedded.html
+++ b/debug/embedded.html
@@ -52,7 +52,7 @@
                 sunt in culpa qui officia deserunt mollit anim id est laborum.
             </p>
             <kicanvas-embed>
-                <kicanvas-source extname="kicad_sch">
+                <kicanvas-source type="sch">
                     (kicad_sch (version 20230121) (generator eeschema) (uuid
                     5d5ad125-5ef1-42a1-a410-a0c4ab262ca6) (paper "A4")
                     (title_block (title "KiCanvas inline sources test") (date

--- a/docs/docs/embedding.md
+++ b/docs/docs/embedding.md
@@ -1,11 +1,12 @@
 # <kicanvas-embed\>: The KiCanvas embedded viewer element
 
 <!-- load kicanvas -->
+
 <script type="module" src="/kicanvas/kicanvas.js"></script>
 
 !!! warning "Work in progress"
 
-    KiCanvas is in **alpha**. This is a proposed API with an incomplete implementation. Everything here is subject to change and you should be cautious if using it on your own web page.
+    KiCanvas is in**alpha**. This is a proposed API with an incomplete implementation. Everything here is subject to change and you should be cautious if using it on your own web page.
 
 The `<kicanvas-embed>` HTML element embeds one or more KiCAD documents onto the page:
 
@@ -13,13 +14,13 @@ The `<kicanvas-embed>` HTML element embeds one or more KiCAD documents onto the 
 <kicanvas-embed src="my-schematic.kicad_sch"></kicanvas-embed>
 ```
 
-<kicanvas-embed src="/examples/simple.kicad_sch"></kicanvas-embed>
+`<kicanvas-embed src="/examples/simple.kicad_sch"></kicanvas-embed>`
 
 The above example shows the most basic usage of the `<kicanvas-embed>` element. It's usage is intentionally similar to the [`<video>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video) and [`<img>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) elements. Through the use of additional [attributes](#attributes) you can control how the document is displayed, control interactivity, and load multiple files.
 
 !!! note
 
-    This page's format is modeled after MDN's [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element). It's intended to be familiar to web developers.
+    This page's format is modeled after MDN's[HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element). It's intended to be familiar to web developers.
 
 ## Installation
 
@@ -98,15 +99,11 @@ You can switch between the displayed files using the project panel on the right 
 
 ### Inline source
 
-!!! warning "Not yet implemented"
-
-    This functionality hasn't been implemented yet
-
 This example shows how to use `<kicanvas-source>` along with inline KiCAD data. In this case, it's a symbol copied from a schematic and pasted into the HTML source:
 
 ```html
 <kicanvas-embed>
-    <kicanvas-source type="schematic">
+    <kicanvas-source type="sch">
         (lib_symbols (symbol "power:+12V" (power) (pin_names (offset 0)) (in_bom
         yes) (on_board yes) (property "Reference" "#PWR" (at 0 -3.81 0) (effects
         (font (size 1.27 1.27)) hide) ) ...
@@ -120,29 +117,31 @@ This example shows how to use `<kicanvas-source>` along with inline KiCAD data. 
 
     Attributes marked with a ⚠️ are either not yet implemented or not completely implemented.
 
--   `controls` - determines if the document is interactive (pan, zoom, etc.) and which controls are available.
-    -   `none` - document is not interactive and behaves like an `<img>` (default)
-    -   `basic` - zoom, pan, and select are available.
-    -   `full` - complete interactive viewer, including side panels.
--   `controlslist` - further customizes the available controls.
-    -   `nooverlay` - don't show the "click or tap to interact" overlay.
-    -   `nofullscreen` - don't show the fullscreen button. ⚠️
-    -   `nodownload` - don't show the download button.
-    -   `download` - show the download button when used with controls="none". ⚠️
-    -   `nosymbols` - don't show the schematic symbols panel. ⚠️
-    -   `nofootprints` - don't show the board footprints panel. ⚠️
-    -   `noobjects` - don't show the board objects panel. ⚠️
-    -   `noproperties` - don't show the selection properties panel. ⚠️
-    -   `noinfo` - don't show the document info panel. ⚠️
-    -   `nopreferences` - don't show the user preferences panel. ⚠️
-    -   `nohelp` - don't show the help panel. ⚠️
--   `src` - the URL of the document to embed. If you want to show multiple documents within a single viewer, you can use multiple child `<kicanvas-source>` elements.
--   `theme` - sets the color theme to use, valid values are `kicad` and `witchhazel`. ⚠️
--   `zoom` - sets the initial view into the document. ⚠️
-    -   `objects` - zooms to show all visible objects (default). ⚠️
-    -   `page` - zooms to show the entire page. ⚠️
-    -   `x y w h` - zooms to the given area, similar to the SVG `viewBox` attribute. For example, `10 10 100 100`. ⚠️
-    -   `<list of references>` - zooms to include the given symbols or footprints. For example `C101 D101 Q101`. ⚠️
+- `controls` - determines if the document is interactive (pan, zoom, etc.) and which controls are available.
+  - `none` - document is not interactive and behaves like an `<img>` (default)
+  - `basic` - zoom, pan, and select are available.
+  - `full` - complete interactive viewer, including side panels.
+- `controlslist` - further customizes the available controls.
+  - `nooverlay` - don't show the "click or tap to interact" overlay.
+  - `nofullscreen` - don't show the fullscreen button. ⚠️
+  - `nodownload` - don't show the download button.
+  - `download` - show the download button when used with controls="none". ⚠️
+  - `nosymbols` - don't show the schematic symbols panel. ⚠️
+  - `nofootprints` - don't show the board footprints panel. ⚠️
+  - `noobjects` - don't show the board objects panel. ⚠️
+  - `noproperties` - don't show the selection properties panel. ⚠️
+  - `noinfo` - don't show the document info panel. ⚠️
+  - `nopreferences` - don't show the user preferences panel. ⚠️
+  - `nohelp` - don't show the help panel. ⚠️
+- `src` - the URL of the document to embed. If you want to show multiple documents within a single viewer, you can use multiple child `<kicanvas-source>` elements.
+- `type` - the type of inline source. Available values include `sch` and `pcb`. It cannot be empty when using the inline source. When the `src` attribute is not empty and the inline source exists, the `src` attribute specified file will be loaded.
+- `originname` - the origin file name. Due to the KiCad dependence on the file name, when using an inline source specify it is a good choice (e.g. using the extern render for Gitea). The default name is `noname` when using the inline source, or file name in the URL when using the `src` attribute.
+- `theme` - sets the color theme to use, valid values are `kicad` and `witchhazel`. ⚠️
+- `zoom` - sets the initial view into the document. ⚠️
+  - `objects` - zooms to show all visible objects (default). ⚠️
+  - `page` - zooms to show the entire page. ⚠️
+  - `x y w h` - zooms to the given area, similar to the SVG `viewBox` attribute. For example, `10 10 100 100`. ⚠️
+  - `<list of references>` - zooms to include the given symbols or footprints. For example `C101 D101 Q101`. ⚠️
 
 ## Events
 
@@ -150,11 +149,11 @@ This example shows how to use `<kicanvas-source>` along with inline KiCAD data. 
 
     This functionality hasn't been implemented yet
 
-| Event Name                   | Fired When                                                                                        |
-| ---------------------------- | ------------------------------------------------------------------------------------------------- |
-| ⚠️ `kicanvas:click`          | The user clicks or taps within the embedded document                                              |
-| ⚠️ `kicanvas:documentchange` | The currently displayed document is changed, either through user interaction or programmatically. |
-| ⚠️ `kicanvas:error`          | An error occurs while loading source files                                                        |
-| ⚠️ `kicanvas:load`           | All sources files have been successfully loaded                                                   |
-| ⚠️ `kicanvas:loadstart`      | KiCanvas begins loading source files                                                              |
-| ⚠️ `kicanvas:select`         | The user selects (or deselects) an object within the document                                     |
+| Event Name                      | Fired When                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| ⚠️`kicanvas:click`          | The user clicks or taps within the embedded document                                              |
+| ⚠️`kicanvas:documentchange` | The currently displayed document is changed, either through user interaction or programmatically. |
+| ⚠️`kicanvas:error`          | An error occurs while loading source files                                                        |
+| ⚠️`kicanvas:load`           | All sources files have been successfully loaded                                                   |
+| ⚠️`kicanvas:loadstart`      | KiCanvas begins loading source files                                                              |
+| ⚠️`kicanvas:select`         | The user selects (or deselects) an object within the document                                     |

--- a/docs/docs/embedding.md
+++ b/docs/docs/embedding.md
@@ -134,7 +134,7 @@ This example shows how to use `<kicanvas-source>` along with inline KiCAD data. 
   - `nopreferences` - don't show the user preferences panel. ⚠️
   - `nohelp` - don't show the help panel. ⚠️
 - `src` - the URL of the document to embed. If you want to show multiple documents within a single viewer, you can use multiple child `<kicanvas-source>` elements.
-- `type` - the type of inline source. Available values include `sch` and `pcb`. It cannot be empty when using the inline source. When the `src` attribute is not empty and the inline source exists, the `src` attribute specified file will be loaded.
+- `type` - the type of inline source. Available values include `sch` and `pcb`. When the `src` attribute is not empty and the inline source exists, the `src` attribute specified file will be loaded and be determined. Otherwise, the file type will be determined by this attribute. If this attribute is empty, the loader will try determined type by the first few characters.
 - `originname` - the origin file name. Due to the KiCad dependence on the file name, when using an inline source specify it is a good choice (e.g. using the extern render for Gitea). The default name is `noname` when using the inline source, or file name in the URL when using the `src` attribute.
 - `theme` - sets the color theme to use, valid values are `kicad` and `witchhazel`. ⚠️
 - `zoom` - sets the initial view into the document. ⚠️

--- a/src/base/dom/drag-drop.ts
+++ b/src/base/dom/drag-drop.ts
@@ -4,10 +4,8 @@
     Full text available at: https://opensource.org/licenses/MIT
 */
 
-import {
-    DragAndDropFileSystem,
-    VirtualFileSystem,
-} from "../../kicanvas/services/vfs";
+import VirtualFileSystem from "../../kicanvas/services/vfs";
+import DragAndDropFileSystem from "../../kicanvas/services/drop-vfs";
 
 export class DropTarget {
     constructor(elm: HTMLElement, callback: (fs: VirtualFileSystem) => void) {

--- a/src/kc-ui/focus-overlay.ts
+++ b/src/kc-ui/focus-overlay.ts
@@ -94,7 +94,6 @@ export class KCUIFocusOverlay extends KCUIElement {
 
         this.#intersection_observer = new IntersectionObserver((entries) => {
             for (const entry of entries) {
-                console.log(entry);
                 if (!entry.isIntersecting) {
                     this.classList.remove("has-focus");
                 }

--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -15,7 +15,8 @@ import {
 import { KCUIElement } from "../../kc-ui";
 import kc_ui_styles from "../../kc-ui/kc-ui.css";
 import { Project } from "../project";
-import { FetchFileSystem, VirtualFileSystem } from "../services/vfs";
+import VirtualFileSystem from "../services/vfs";
+import FetchFileSystem from "../services/fetch-vfs";
 import type { KCBoardAppElement } from "./kc-board/app";
 import type { KCSchematicAppElement } from "./kc-schematic/app";
 

--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -116,20 +116,24 @@ class KiCanvasEmbedElement extends KCUIElement {
                 // If the src attribute is None, add the text children.
                 // Check the "type" attribute
                 // because the render uses file extension name to determine the sch or PCB file so we must know the "type"
-                if (src_elm.extname === null) {
+                if (src_elm.type === null) {
                     log.warn(
                         'Missing "extname" attribute for kicanvas-source element.',
                     );
                     continue;
                 }
-                if (
-                    ["kicad_sch", "kicad_pcb", "kicad_pro"].indexOf(
-                        src_elm.extname,
-                    ) === -1
-                ) {
-                    log.warn('Invaild value of attribute "extname"');
+
+                // Convert the extension name. That make `project.ts` determine the file type is possible.
+                let file_extname = "";
+                if (src_elm.type === "sch") {
+                    file_extname = "kicad_sch";
+                } else if (src_elm.type === "pcb") {
+                    file_extname = "kicad_pcb";
+                } else {
+                    log.warn('Invaild value of attribute "type"');
                     continue;
                 }
+
                 for (const child of src_elm.childNodes) {
                     if (child.nodeType !== Node.TEXT_NODE) {
                         log.warn("kicanvas-source children are not empty.");
@@ -139,7 +143,7 @@ class KiCanvasEmbedElement extends KCUIElement {
                     const child_text = child.nodeValue ?? "";
                     const source_content = child_text.trimStart();
                     const source_filename =
-                        src_elm.originfile ?? `noname.${src_elm.extname}`;
+                        src_elm.originname ?? `noname.${file_extname}`;
                     // append to the sources
                     sources.push(
                         new FetchFileSource(
@@ -227,10 +231,10 @@ class KiCanvasSourceElement extends CustomElement {
     src: string | null;
 
     @attribute({ type: String })
-    extname: string | null;
+    type: string | null;
 
     @attribute({ type: String })
-    originfile: string | null;
+    originname: string | null;
 }
 
 window.customElements.define("kicanvas-source", KiCanvasSourceElement);

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -12,7 +12,7 @@ import { sprites_url } from "../icons/sprites";
 import { Project } from "../project";
 import { GitHub } from "../services/github";
 import { GitHubFileSystem } from "../services/github-vfs";
-import FetchFileSystem from "../services/fetch-vfs";
+import FetchFileSystem, { FetchFileSource } from "../services/fetch-vfs";
 import type VirtualFileSystem from "../services/vfs";
 import { KCBoardAppElement } from "./kc-board/app";
 import { KCSchematicAppElement } from "./kc-schematic/app";
@@ -83,7 +83,9 @@ class KiCanvasShellElement extends KCUIElement {
 
         later(async () => {
             if (this.src) {
-                const vfs = new FetchFileSystem([this.src]);
+                const vfs = new FetchFileSystem([
+                    new FetchFileSource("uri", this.src),
+                ]);
                 await this.setup_project(vfs);
                 return;
             }

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -12,7 +12,8 @@ import { sprites_url } from "../icons/sprites";
 import { Project } from "../project";
 import { GitHub } from "../services/github";
 import { GitHubFileSystem } from "../services/github-vfs";
-import { FetchFileSystem, type VirtualFileSystem } from "../services/vfs";
+import FetchFileSystem from "../services/fetch-vfs";
+import type VirtualFileSystem from "../services/vfs";
 import { KCBoardAppElement } from "./kc-board/app";
 import { KCSchematicAppElement } from "./kc-schematic/app";
 

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -15,7 +15,7 @@ import type {
     SchematicSheet,
     SchematicSheetInstance,
 } from "../kicad/schematic";
-import type { VirtualFileSystem } from "./services/vfs";
+import type VirtualFileSystem from "./services/vfs";
 
 const log = new Logger("kicanvas:project");
 

--- a/src/kicanvas/services/drop-vfs.ts
+++ b/src/kicanvas/services/drop-vfs.ts
@@ -1,0 +1,89 @@
+/*
+    Copyright (c) 2023 XiangYyang
+*/
+
+import { initiate_download } from "../../base/dom/download";
+import VirtualFileSystem from "./vfs";
+
+/**
+ * Virtual file system for HTML drag and drop (DataTransfer)
+ */
+export default class DragAndDropFileSystem extends VirtualFileSystem {
+    constructor(private items: FileSystemFileEntry[]) {
+        super();
+    }
+
+    static async fromDataTransfer(dt: DataTransfer) {
+        let items: FileSystemEntry[] = [];
+
+        // Pluck items out as webkit entries (either FileSystemFileEntry or
+        // FileSystemDirectoryEntry)
+        for (let i = 0; i < dt.items.length; i++) {
+            const item = dt.items[i]?.webkitGetAsEntry();
+            if (item) {
+                items.push(item);
+            }
+        }
+
+        // If it's just one directory then open it and set all of our items
+        // to its contents.
+        if (items.length == 1 && items[0]?.isDirectory) {
+            const reader = (
+                items[0] as FileSystemDirectoryEntry
+            ).createReader();
+
+            items = [];
+
+            await new Promise((resolve, reject) => {
+                reader.readEntries((entries) => {
+                    for (const entry of entries) {
+                        if (!entry.isFile) {
+                            continue;
+                        }
+                        items.push(entry);
+                    }
+                    resolve(true);
+                }, reject);
+            });
+        }
+
+        return new DragAndDropFileSystem(items as FileSystemFileEntry[]);
+    }
+
+    public override *list() {
+        for (const entry of this.items) {
+            yield entry.name;
+        }
+    }
+
+    public override async has(name: string): Promise<boolean> {
+        for (const entry of this.items) {
+            if (entry.name == name) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public override async get(name: string): Promise<File> {
+        let file_entry: FileSystemFileEntry | null = null;
+        for (const entry of this.items) {
+            if (entry.name == name) {
+                file_entry = entry;
+                break;
+            }
+        }
+
+        if (file_entry == null) {
+            throw new Error(`File ${name} not found!`);
+        }
+
+        return await new Promise((resolve, reject) => {
+            file_entry!.file(resolve, reject);
+        });
+    }
+
+    public async download(name: string) {
+        initiate_download(await this.get(name));
+    }
+}

--- a/src/kicanvas/services/fetch-vfs.ts
+++ b/src/kicanvas/services/fetch-vfs.ts
@@ -1,0 +1,57 @@
+/*
+    Copyright (c) 2023 XiangYyang
+*/
+
+import { initiate_download } from "../../base/dom/download";
+import { basename } from "../../base/paths";
+import VirtualFileSystem from "./vfs";
+
+/**
+ * Virtual file system for URLs via Fetch or inline sources
+ */
+export default class FetchFileSystem extends VirtualFileSystem {
+    private urls: Map<string, URL> = new Map();
+
+    constructor(urls: (string | URL)[]) {
+        super();
+
+        for (const item of urls) {
+            const url = new URL(item, window.location.toString());
+            const name = basename(url);
+            this.urls.set(name, url);
+        }
+    }
+
+    public override *list() {
+        yield* this.urls.keys();
+    }
+
+    public override async has(name: string) {
+        return Promise.resolve(this.urls.has(name));
+    }
+
+    public override async get(name: string): Promise<File> {
+        const url = this.urls.get(name);
+
+        if (!url) {
+            throw new Error(`File ${name} not found!`);
+        }
+
+        const request = new Request(url, { method: "GET" });
+        const response = await fetch(request);
+
+        if (!response.ok) {
+            throw new Error(
+                `Unable to load ${url}: ${response.status} ${response.statusText}`,
+            );
+        }
+
+        const blob = await response.blob();
+
+        return new File([blob], name);
+    }
+
+    public async download(name: string) {
+        initiate_download(await this.get(name));
+    }
+}

--- a/src/kicanvas/services/fetch-vfs.ts
+++ b/src/kicanvas/services/fetch-vfs.ts
@@ -5,50 +5,116 @@
 import { initiate_download } from "../../base/dom/download";
 import { basename } from "../../base/paths";
 import VirtualFileSystem from "./vfs";
+import { Logger } from "../../base/log";
+
+const log = new Logger("kicanvas:fetchfs");
+
+/**
+ * File sources
+ */
+export class FetchFileSource {
+    constructor(
+        origin: "uri" | "content",
+        value: string,
+        name: string | undefined = undefined,
+    ) {
+        this.origin = origin;
+        if (this.origin === "uri") {
+            const url = new URL(value, window.location.toString());
+            this.value = url;
+            this.origin_name = name ?? basename(url);
+            log.info(
+                `Load file from url ${url}, origin name: ${this.origin_name}`,
+            );
+        } else {
+            this.value = value;
+            this.origin_name = name ?? "noname";
+            log.info(
+                `Load file from inline source, origin name: ${this.origin_name}`,
+            );
+        }
+    }
+
+    /**
+     * Get the origin name of this item
+     */
+    public get_origin_name(): string {
+        return this.origin_name;
+    }
+
+    /**
+     * Get the file content from URL or inline sources
+     */
+    public async get_content(): Promise<File> {
+        if (this.origin === "uri") {
+            const url = this.value as URL;
+
+            const request = new Request(url, { method: "GET" });
+
+            const response = await fetch(request);
+
+            if (!response.ok) {
+                throw new Error(
+                    `Unable to load ${url}: ${response.status} ${response.statusText}`,
+                );
+            }
+
+            const blob = await response.blob();
+
+            return new File([blob], this.origin_name);
+        } else {
+            const content = this.value as string;
+            const blob = new Blob([content], { type: "text/plain" });
+            return new File([blob], this.origin_name);
+        }
+    }
+
+    /**
+     * Origin, from URI or from raw content.
+     */
+    private origin: "uri" | "content";
+
+    /**
+     * Value, URL (origin === "uri") or string (origin === "content")
+     */
+    private value: URL | string;
+
+    /**
+     * File name
+     */
+    private origin_name: string;
+}
 
 /**
  * Virtual file system for URLs via Fetch or inline sources
  */
 export default class FetchFileSystem extends VirtualFileSystem {
-    private urls: Map<string, URL> = new Map();
+    private items: Map<string, FetchFileSource> = new Map();
 
-    constructor(urls: (string | URL)[]) {
+    constructor(items: FetchFileSource[]) {
         super();
 
-        for (const item of urls) {
-            const url = new URL(item, window.location.toString());
-            const name = basename(url);
-            this.urls.set(name, url);
+        for (const item of items) {
+            this.items.set(item.get_origin_name(), item);
         }
     }
 
     public override *list() {
-        yield* this.urls.keys();
+        yield* this.items.keys();
     }
 
     public override async has(name: string) {
-        return Promise.resolve(this.urls.has(name));
+        return Promise.resolve(this.items.has(name));
     }
 
     public override async get(name: string): Promise<File> {
-        const url = this.urls.get(name);
+        const item = this.items.get(name);
 
-        if (!url) {
+        if (!item) {
             throw new Error(`File ${name} not found!`);
         }
 
-        const request = new Request(url, { method: "GET" });
-        const response = await fetch(request);
-
-        if (!response.ok) {
-            throw new Error(
-                `Unable to load ${url}: ${response.status} ${response.statusText}`,
-            );
-        }
-
-        const blob = await response.blob();
-
-        return new File([blob], name);
+        return item.get_content();
     }
 
     public async download(name: string) {

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -7,7 +7,7 @@
 import { initiate_download } from "../../base/dom/download";
 import { basename, dirname, extension } from "../../base/paths";
 import { GitHub, GitHubUserContent } from "./github";
-import { VirtualFileSystem } from "./vfs";
+import VirtualFileSystem from "./vfs";
 
 const kicad_extensions = ["kicad_pcb", "kicad_pro", "kicad_sch"];
 const gh_user_content = new GitHubUserContent();

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -4,9 +4,6 @@
     Full text available at: https://opensource.org/licenses/MIT
 */
 
-import { initiate_download } from "../../base/dom/download";
-import { basename } from "../../base/paths";
-
 /**
  * Virtual file system abstract class.
  *
@@ -14,7 +11,7 @@ import { basename } from "../../base/paths";
  * It's implemented using Drag and Drop and GitHub to provide a common interface
  * for interacting and loading files.
  */
-export abstract class VirtualFileSystem {
+export default abstract class VirtualFileSystem {
     public abstract list(): Generator<string>;
     public abstract get(name: string): Promise<File>;
     public abstract has(name: string): Promise<boolean>;
@@ -38,138 +35,5 @@ export abstract class VirtualFileSystem {
                 yield filename;
             }
         }
-    }
-}
-
-/**
- * Virtual file system for URLs via Fetch
- */
-export class FetchFileSystem extends VirtualFileSystem {
-    private urls: Map<string, URL> = new Map();
-
-    constructor(urls: (string | URL)[]) {
-        super();
-
-        for (const item of urls) {
-            const url = new URL(item, window.location.toString());
-            const name = basename(url);
-            this.urls.set(name, url);
-        }
-    }
-
-    public override *list() {
-        yield* this.urls.keys();
-    }
-
-    public override async has(name: string) {
-        return Promise.resolve(this.urls.has(name));
-    }
-
-    public override async get(name: string): Promise<File> {
-        const url = this.urls.get(name);
-
-        if (!url) {
-            throw new Error(`File ${name} not found!`);
-        }
-
-        const request = new Request(url, { method: "GET" });
-        const response = await fetch(request);
-
-        if (!response.ok) {
-            throw new Error(
-                `Unable to load ${url}: ${response.status} ${response.statusText}`,
-            );
-        }
-
-        const blob = await response.blob();
-
-        return new File([blob], name);
-    }
-
-    public async download(name: string) {
-        initiate_download(await this.get(name));
-    }
-}
-
-/**
- * Virtual file system for HTML drag and drop (DataTransfer)
- */
-export class DragAndDropFileSystem extends VirtualFileSystem {
-    constructor(private items: FileSystemFileEntry[]) {
-        super();
-    }
-
-    static async fromDataTransfer(dt: DataTransfer) {
-        let items: FileSystemEntry[] = [];
-
-        // Pluck items out as webkit entries (either FileSystemFileEntry or
-        // FileSystemDirectoryEntry)
-        for (let i = 0; i < dt.items.length; i++) {
-            const item = dt.items[i]?.webkitGetAsEntry();
-            if (item) {
-                items.push(item);
-            }
-        }
-
-        // If it's just one directory then open it and set all of our items
-        // to its contents.
-        if (items.length == 1 && items[0]?.isDirectory) {
-            const reader = (
-                items[0] as FileSystemDirectoryEntry
-            ).createReader();
-
-            items = [];
-
-            await new Promise((resolve, reject) => {
-                reader.readEntries((entries) => {
-                    for (const entry of entries) {
-                        if (!entry.isFile) {
-                            continue;
-                        }
-                        items.push(entry);
-                    }
-                    resolve(true);
-                }, reject);
-            });
-        }
-
-        return new DragAndDropFileSystem(items as FileSystemFileEntry[]);
-    }
-
-    public override *list() {
-        for (const entry of this.items) {
-            yield entry.name;
-        }
-    }
-
-    public override async has(name: string): Promise<boolean> {
-        for (const entry of this.items) {
-            if (entry.name == name) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public override async get(name: string): Promise<File> {
-        let file_entry: FileSystemFileEntry | null = null;
-        for (const entry of this.items) {
-            if (entry.name == name) {
-                file_entry = entry;
-                break;
-            }
-        }
-
-        if (file_entry == null) {
-            throw new Error(`File ${name} not found!`);
-        }
-
-        return await new Promise((resolve, reject) => {
-            file_entry!.file(resolve, reject);
-        });
-    }
-
-    public async download(name: string) {
-        initiate_download(await this.get(name));
     }
 }


### PR DESCRIPTION
I tried to add the inline source support by changing the `FetchFileSystem`.

I added a `FetchFileSource` class to help determine data sources, from URL or inline sources.

When the source is an inline source, the `load_src` method of `KiCanvasEmbedElement` will use two attributes. The filename will be obtained from the attribute `originname` and the `type` attribute describes the file type. When the `originname` attribute is empty, that will generate a default name for this file. Likewise, it will determine whether the inline source is sch or pcb by the first few characters when the `type` attribute is empty.

Finally, the file type and the origin name will be contacted, and it as the inline source file name.