### PR TITLE
Add ability to do recursive loading

### DIFF
--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -83,6 +83,8 @@ class KiCanvasEmbedElement extends KCUIElement {
     @attribute({ type: String })
     zoom: "objects" | "page" | string | null;
 
+    custom_resolver: ((name: string) => URL) | null = null;
+
     #schematic_app: KCSchematicAppElement;
     #board_app: KCBoardAppElement;
 
@@ -115,7 +117,7 @@ class KiCanvasEmbedElement extends KCUIElement {
             return;
         }
 
-        const vfs = new FetchFileSystem(sources);
+        const vfs = new FetchFileSystem(sources, this.custom_resolver);
         await this.#setup_project(vfs);
     }
 

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -63,7 +63,6 @@ export class Project extends EventTarget implements IDisposable {
                         // Missing schematic, attempt to fetch
                         promises.push(this.#load_file(sheet.sheetfile));
                     }
-
                 }
             }
             await Promise.all(promises);

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -54,12 +54,12 @@ export class FetchFileSystem extends VirtualFileSystem {
     }
 
     #resolve(filepath: string | URL): URL {
-        if (typeof filepath === 'string') {
+        if (typeof filepath === "string") {
             const cached_url = this.urls.get(filepath);
             if (cached_url) {
-                return cached_url;  
+                return cached_url;
             } else {
-                const url = this.resolver(filepath)
+                const url = this.resolver(filepath);
                 const name = basename(url);
                 this.urls.set(name, url);
                 return url;
@@ -68,13 +68,16 @@ export class FetchFileSystem extends VirtualFileSystem {
         return filepath;
     }
 
-    constructor(urls: (string | URL)[], resolve_file: ((name: string) => URL) | null = null) {
+    constructor(
+        urls: (string | URL)[],
+        resolve_file: ((name: string) => URL) | null = null,
+    ) {
         super();
 
-        this.resolver = resolve_file ?? this.#default_resolver
+        this.resolver = resolve_file ?? this.#default_resolver;
 
         for (const item of urls) {
-            this.#resolve(item)
+            this.#resolve(item);
         }
     }
 

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -55,7 +55,7 @@ export class FetchFileSystem extends VirtualFileSystem {
 
     #resolve(filepath: string | URL): URL {
         if (typeof filepath === 'string') {
-            let cached_url = this.urls.get(filepath);
+            const cached_url = this.urls.get(filepath);
             if (cached_url) {
                 return cached_url;  
             } else {

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -46,14 +46,35 @@ export abstract class VirtualFileSystem {
  */
 export class FetchFileSystem extends VirtualFileSystem {
     private urls: Map<string, URL> = new Map();
+    private resolver!: (name: string) => URL;
 
-    constructor(urls: (string | URL)[]) {
+    #default_resolver(name: string): URL {
+        const url = new URL(name, window.location.toString());
+        return url;
+    }
+
+    #resolve(filepath: string | URL): URL {
+        if (typeof filepath === 'string') {
+            let cached_url = this.urls.get(filepath);
+            if (cached_url) {
+                return cached_url;  
+            } else {
+                const url = this.resolver(filepath)
+                const name = basename(url);
+                this.urls.set(name, url);
+                return url;
+            }
+        }
+        return filepath;
+    }
+
+    constructor(urls: (string | URL)[], resolve_file: ((name: string) => URL) | null = null) {
         super();
 
+        this.resolver = resolve_file ?? this.#default_resolver
+
         for (const item of urls) {
-            const url = new URL(item, window.location.toString());
-            const name = basename(url);
-            this.urls.set(name, url);
+            this.#resolve(item)
         }
     }
 
@@ -66,7 +87,7 @@ export class FetchFileSystem extends VirtualFileSystem {
     }
 
     public override async get(name: string): Promise<File> {
-        const url = this.urls.get(name);
+        const url = this.#resolve(name);
 
         if (!url) {
             throw new Error(`File ${name} not found!`);


### PR DESCRIPTION
This will automatically load any identifiable schematic file recursively. It supports a custom resolver for kicanvas-embed webcomponent which allows the user to specify where to find other files.

A working example exists at https://git.devdroplets.com/Ryan/violent-scripts/-/blob/master/scripts/kicanvas-gitlab/kicanvas-gitlab.ts ; a user-script which adds KiCanvas to gitlabs file preview page

(this should resolve #77 at least partially)