### PR TITLE
fix: range input styling on gecko based browsers

### DIFF
--- a/src/kc-ui/range.ts
+++ b/src/kc-ui/range.ts
@@ -62,13 +62,27 @@ export class KCUIRangeElement extends KCUIElement {
                 border-radius: 0.5em;
                 background: var(--input-range-bg);
             }
+            input[type="range"]::-moz-range-track {
+                box-sizing: border-box;
+                height: 0.5em;
+                border: 1px solid transparent;
+                border-radius: 0.5em;
+                background: var(--input-range-bg);
+            }
 
             input[type="range"]:hover::-webkit-slider-runnable-track,
             input[type="range"]:focus::-webkit-slider-runnable-track {
                 border: 1px solid var(--input-range-hover-bg);
             }
+            input[type="range"]:hover::-moz-range-track,
+            input[type="range"]:focus::-moz-range-track {
+                border: 1px solid var(--input-range-hover-bg);
+            }
 
             input[type="range"]:disabled::-webkit-slider-runnable-track {
+                background: var(--input-range-disabled-bg);
+            }
+            input[type="range"]:disabled::-moz-range-track {
                 background: var(--input-range-disabled-bg);
             }
 
@@ -81,8 +95,19 @@ export class KCUIRangeElement extends KCUIElement {
                 margin-top: -0.3em;
                 background: var(--input-range-fg);
             }
+            input[type="range"]::-moz-range-thumb {
+                border: none;
+                height: 1em;
+                width: 1em;
+                border-radius: 100%;
+                margin-top: -0.3em;
+                background: var(--input-range-fg);
+            }
 
             input[type="range"]:focus::-webkit-slider-thumb {
+                box-shadow: var(--input-range-handle-shadow);
+            }
+            input[type="range"]:focus::-moz-range-thumb {
                 box-shadow: var(--input-range-handle-shadow);
             }
         `,


### PR DESCRIPTION
Does what it says on the tin!

This PR aims to fix styling issues described in [this issue](https://github.com/theacodes/kicanvas/issues/97), namely that on gecko based browser like firefox, the range input track styling is not being applied. It makes it a bit difficult to realize that those are actually sliders.

Two other small changes:
- firefox adds a gross border to the range thumb, so went ahead and removed that.
- the border radius looked a little chonky so I turned it back into a circle

Expected (chrome):
<img width="332" alt="" src="https://github.com/user-attachments/assets/15228213-dca6-4dac-bb20-55cd7c9d275e">

Actual (firefox):
<img width="332" alt="" src="https://github.com/user-attachments/assets/4899ae7a-9f65-4722-8c3f-1ba49466c626">

Firefox after fix:
<img width="332" alt="" src="https://github.com/user-attachments/assets/90b28dc6-91eb-47c4-9204-d17d2b678435">

