### PR TITLE
Handle base64 encoded data atom in the tokenizer

### DIFF
--- a/src/kicad/tokenizer.ts
+++ b/src/kicad/tokenizer.ts
@@ -110,7 +110,10 @@ export function* tokenize(input: string) {
                 state = State.number;
                 start_idx = i;
                 continue;
-            } else if (is_alpha(c) || ["*", "&", "$", "/", "%", "|"].includes(c)) {
+            } else if (
+                is_alpha(c) ||
+                ["*", "&", "$", "/", "%", "|"].includes(c)
+            ) {
                 state = State.atom;
                 start_idx = i;
                 continue;

--- a/test/kicad/tokenizer.test.ts
+++ b/test/kicad/tokenizer.test.ts
@@ -131,7 +131,10 @@ suite("kicad.tokenizer.tokenize(): s-expression tokenizer", function () {
         assert_tokens(tokens, [
             OPEN_TOKEN,
             [ATOM, "data"],
-            [ATOM, "|KLUv/aCvzgcAAAAQiVBORw0KGgoAAAANSUhEUgAABiAAAANoCAYAAABJLCIrAAAABHNCSVQICAgI"],
+            [
+                ATOM,
+                "|KLUv/aCvzgcAAAAQiVBORw0KGgoAAAANSUhEUgAABiAAAANoCAYAAABJLCIrAAAABHNCSVQICAgI",
+            ],
             CLOSE_TOKEN,
         ]);
     });


### PR DESCRIPTION
This should fix #112. The tokenizer shouldn't choke now on `(data` tokens with base64 encoded data (that happen to start with a pipe separator).