### PR TITLE
fix: display alternate pin functions in sch symbol

### DIFF
--- a/src/kicad/schematic.ts
+++ b/src/kicad/schematic.ts
@@ -1404,7 +1404,7 @@ export class SchematicSymbolInstance {
 export class PinInstance {
     number: string;
     uuid: string;
-    alternate: string;
+    alternate?: string;
 
     constructor(
         expr: Parseable,

--- a/src/viewers/schematic/painters/pin.ts
+++ b/src/viewers/schematic/painters/pin.ts
@@ -201,7 +201,7 @@ export class PinPainter extends SchematicItemPainter {
     draw_name_and_number(gfx: Renderer, pin: PinInfo) {
         const def = pin.def;
         const libsym = pin.pin.parent.lib_symbol;
-        const name = def.name.text;
+        const name = pin.pin.alternate ?? def.name.text;
         const number = def.number.text;
         const pin_length = def.length;
         const hide_pin_names = libsym.pin_names.hide || !name || name == "~";


### PR DESCRIPTION
This PR fixes issue #151, and now the schematic symbols display the alternative pin functionality correctly.

<img width="801" height="591" alt="image" src="https://github.com/user-attachments/assets/0bed273f-27d1-40ce-ba1d-5fbd219d7843" />
