### PR TITLE
add: parse kicad9 embeded_files property

### DIFF
--- a/src/kicad/board.ts
+++ b/src/kicad/board.ts
@@ -13,6 +13,7 @@ import {
     Stroke,
     TitleBlock,
     expand_text_vars,
+    EmbeddedFile,
     StrokeParams,
     type HasNetName,
     type HasUniqueID,
@@ -51,6 +52,8 @@ export class KicadPCB {
     vias: Via[] = [];
     drawings: Drawing[] = [];
     groups: Group[] = [];
+    embedded_fonts: boolean = false;
+    embedded_files: EmbeddedFile[] = [];
 
     constructor(
         public filename: string,
@@ -98,6 +101,8 @@ export class KicadPCB {
                 P.collection("drawings", "gr_rect", T.item(GrRect, this)),
                 P.collection("drawings", "gr_text", T.item(GrText, this)),
                 P.collection("groups", "group", T.item(Group)),
+                P.pair("embedded_fonts", T.boolean),
+                P.list("embedded_files", T.item(EmbeddedFile)),
             ),
         );
 
@@ -864,6 +869,8 @@ export class Footprint implements HasUniqueID {
     #pads_by_number = new Map<string, Pad>();
     zones: Zone[] = [];
     models: Model[] = [];
+    embedded_fonts: boolean = false;
+    embedded_files: EmbeddedFile[] = [];
     #bbox: BBox;
 
     constructor(
@@ -921,6 +928,8 @@ export class Footprint implements HasUniqueID {
                 P.collection("zones", "zone", T.item(Zone, this)),
                 P.collection("models", "model", T.item(Model)),
                 P.collection("pads", "pad", T.item(Pad, this)),
+                P.pair("embedded_fonts", T.boolean),
+                P.list("embedded_files", T.item(EmbeddedFile)),
             ),
         );
 

--- a/src/kicad/common.ts
+++ b/src/kicad/common.ts
@@ -362,6 +362,48 @@ export class Stroke {
     }
 }
 
+export enum EmbeddedFileType {
+    Datasheet = "datasheet",
+    Font = "font",
+    Model = "model",
+    Worksheet = "worksheet",
+    Other = "other",
+}
+
+export class EmbeddedFile {
+    name: string;
+    type: EmbeddedFileType;
+    data?: string;
+    checksum: string;
+
+    constructor(expr: Parseable) {
+        Object.assign(
+            this,
+            parse_expr(
+                expr,
+                P.start("file"),
+                P.pair("name", T.string),
+                P.pair("type", T.string),
+                P.pair("data", T.string),
+                P.pair("checksum", T.string),
+            ),
+        );
+    }
+
+    async decompress_file(): Promise<File | undefined> {
+        // see also:
+        // https://gitlab.com/kicad/code/kicad/-/blob/master/common/embedded_files.cpp#L253
+        if (!this.data) {
+            // need be found in the board file
+            return undefined;
+        }
+
+        // TODO
+
+        return undefined;
+    }
+}
+
 /** Stroke and additional parameters for dashed lines. */
 export class StrokeParams {
     stroke: Stroke;

--- a/src/kicad/schematic.ts
+++ b/src/kicad/schematic.ts
@@ -14,6 +14,7 @@ import {
     Paper,
     Stroke,
     TitleBlock,
+    EmbeddedFile,
     expand_text_vars,
     unescape_string,
 } from "./common";
@@ -79,6 +80,8 @@ export class KicadSch {
     sheet_instances?: SheetInstances;
     symbol_instances?: SymbolInstances;
     sheets: SchematicSheet[] = [];
+    embedded_fonts: boolean = false;
+    embedded_files: EmbeddedFile[] = [];
 
     constructor(
         public filename: string,
@@ -91,6 +94,7 @@ export class KicadSch {
                 P.start("kicad_sch"),
                 P.pair("version", T.number),
                 P.pair("generator", T.string),
+                P.pair("generator_version", T.string),
                 P.pair("uuid", T.string),
                 P.item("paper", Paper),
                 P.item("title_block", TitleBlock),
@@ -127,6 +131,8 @@ export class KicadSch {
                 P.item("sheet_instances", SheetInstances),
                 P.item("symbol_instances", SymbolInstances),
                 P.collection("sheets", "sheet", T.item(SchematicSheet, this)),
+                P.pair("embedded_fonts", T.boolean),
+                P.list("embedded_files", T.item(EmbeddedFile)),
             ),
         );
 
@@ -813,6 +819,8 @@ export class LibSymbol {
     drawings: Drawing[] = [];
     pins: PinDefinition[] = [];
     units: Map<number, LibSymbol[]> = new Map();
+    embedded_fonts = false;
+    embedded_files: EmbeddedFile[] = [];
 
     #pins_by_number: Map<string, PinDefinition> = new Map();
     #properties_by_id: Map<number, Property> = new Map();
@@ -853,6 +861,8 @@ export class LibSymbol {
                 P.collection("drawings", "rectangle", T.item(Rectangle, this)),
                 P.collection("drawings", "text", T.item(LibText, this)),
                 P.collection("drawings", "textbox", T.item(TextBox, this)),
+                P.pair("embedded_fonts", T.boolean),
+                P.collection("embedded_files", "file", T.item(EmbeddedFile)),
             ),
         );
 


### PR DESCRIPTION
This PR adds support for parsing the KiCad 9 `embeded_files` property. It resolved all the warnings relating to the `embeded_files` and `embeded_fonts` property.

<img width="593" height="224" alt="image" src="https://github.com/user-attachments/assets/b1ea635c-3932-4d6b-a42e-ab9518168586" />
