### PR TITLE
fix: highlight pad copper layers

### DIFF
--- a/src/viewers/board/layers.ts
+++ b/src/viewers/board/layers.ts
@@ -162,6 +162,30 @@ function is_virtual_for(physical_layer: string, layer_name: string) {
     );
 }
 
+function is_pad_layer_for(physical_layer: string, layer_name: string) {
+    let pad_layer_prefix = ":invaild";
+
+    if (physical_layer === LayerNames.f_cu) {
+        pad_layer_prefix = ":Pads:Front";
+    } else if (physical_layer === LayerNames.b_cu) {
+        pad_layer_prefix = ":Pads:Back";
+    }
+
+    // TODO:
+    // for the thru_hole pads, it includes all copper layers,
+    // and we cannot determine here.
+    // It just work on F.Cu and B.Cu
+    const is_thru_hole =
+        layer_name === LayerNames.pad_holes_netname ||
+        layer_name === LayerNames.pad_holes ||
+        layer_name === LayerNames.non_plated_holes;
+
+    const is_pad_copper = layer_name.startsWith(pad_layer_prefix);
+    const is_pad_thru_hole = is_thru_hole && is_copper(physical_layer);
+
+    return is_pad_copper || is_pad_thru_hole;
+}
+
 function is_copper(name: string) {
     return name.endsWith(".Cu");
 }
@@ -479,7 +503,10 @@ export class LayerSet extends BaseLayerSet {
         }
 
         const matching_layers = this.query(
-            (l) => l.name == layer_name || is_virtual_for(layer_name, l.name),
+            (l) =>
+                l.name == layer_name ||
+                is_virtual_for(layer_name, l.name) ||
+                is_pad_layer_for(layer_name, l.name),
         );
 
         super.highlight(matching_layers);


### PR DESCRIPTION
This PR fixes issue #156. It highlighting the copper layer of the pad correctly.

It has some issues with the through-hole pads. The pads' layer stack is incomplete, we cannot get the pad stack in the `highlight` function. So the inner copper layers and solid mask layers aren't displayed correctly. I may need to look into KiCad's logic more.

Anyway, this fix works well on the front and bottom copper layers.

This PR

<img width="1150" height="726" alt="image" src="https://github.com/user-attachments/assets/b1c6c847-3be9-4d99-8368-3fcdddad070d" />

**The known issue**. The inner layer of the through-hole pad has not been rendered correctly.

<img width="1169" height="1022" alt="image" src="https://github.com/user-attachments/assets/1f7730db-aa4b-44b3-a014-4e3aec63ce9e" />

KiCad 9.0

<img width="1272" height="794" alt="image" src="https://github.com/user-attachments/assets/6a1e6fc7-5208-4cb6-8224-66bc6f2fc33e" />
