### PR TITLE
fix: keep pad name text upright

### DIFF
--- a/src/viewers/board/painter.ts
+++ b/src/viewers/board/painter.ts
@@ -562,6 +562,15 @@ class PadPainter extends NetNameItemPainter {
 
             max_font_size = Math.min(max_font_size, 10);
 
+            // keep the text upright
+            const pad_rotate = pad.at.rotation;
+            while (pad_rotate + text_rotated > 90) {
+                text_rotated -= 180;
+            }
+            while (pad_rotate + text_rotated <= -90) {
+                text_rotated += 180;
+            }
+
             // calcuate the offset for pad number and net name if necessary
             let y_offset_pad_num = 0;
             let y_offset_pad_net = 0;


### PR DESCRIPTION
This PR fixes a bug in #145. It makes sure that the text stays upright.

This PR

<img width="1129" height="1062" alt="image" src="https://github.com/user-attachments/assets/dfee52c2-65df-434e-9efd-778ab4df1543" />

Latest version (commit f43297ecce0d0eda919543e01ae3245686b99ccb)

<img width="961" height="955" alt="image" src="https://github.com/user-attachments/assets/fa4eac66-340d-4b1d-9e36-c2f91eaf08a3" />
