### PR TITLE
Assort comment and string fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ KiCanvas is very early in its development and there's a ton of stuff that hasn't
 
 ## Known issues
 
-In general, please check the [GitHub issues] page before filing new issues. Some high-level things that we known won't work:
+In general, please check the [GitHub issues] page before filing new issues. Some high-level things that we know won't work:
 
 - Any KiCAD 5 files, KiCanvas can only parse files from KiCAD 6 and later.
 - Some KiCAD 7 features might not be fully implemented, such as custom fonts in schematics.

--- a/docs/docs/license.md
+++ b/docs/docs/license.md
@@ -33,7 +33,7 @@ derivative works.
 
 This project contains copies or makes use of other works. These works and their respective license and terms are:
 
-- Earcut by Mapbox, licensed under the ISC license. Retrived from https://github.com/mapbox/earcut.
+- Earcut by Mapbox, licensed under the ISC license. Retrieved from https://github.com/mapbox/earcut.
 - Newstroke by Vladimir Uryvaev, Lingdong Huang, Adobe, and KiCAD contributors. Originally licensed under Creative Commons CC0 1.0, amended with an MIT-like license, and utilizes glyphs that are licensed under the SIL Open Font License Version 1.1.
 - Material Symbols by Google, licensed under the Apache License, Version 2.0. Retrieved from https://github.com/google/material-design-icons.
 - Nunito by Vernon Adams, Manvel Shmavonyan, licensed under the Open Font License. Retrieved from https://fonts.google.com/specimen/Nunito/about

--- a/src/base/dom/size-observer.ts
+++ b/src/base/dom/size-observer.ts
@@ -9,7 +9,7 @@ import type { IDisposable } from "../disposable";
 type ResizeObserverCallback = (target: HTMLElement) => void;
 
 /**
- * Wrapper over ResizeObserver that implmenets IDisposable
+ * Wrapper over ResizeObserver that implements IDisposable
  */
 export class SizeObserver implements IDisposable {
     #observer: ResizeObserver;

--- a/src/base/events.ts
+++ b/src/base/events.ts
@@ -7,7 +7,7 @@
 import type { IDisposable } from "./disposable";
 
 /**
- * Adds an event listener and wraps it as a Disposable. When disposed, the
+ * Adds an event listener and wraps it as a Disposable. When disposed of, the
  * event listener is removed from the target.
  */
 export function listen<K extends keyof GlobalEventHandlersEventMap>(

--- a/src/base/math/angle.ts
+++ b/src/base/math/angle.ts
@@ -84,7 +84,7 @@ export class Angle {
     }
 
     /**
-     * Returns a new Angle representing the different of this angle and the given angle.
+     * Returns a new Angle representing the difference between this angle and the given angle.
      */
     sub(other: AngleLike) {
         const diff = this.radians - new Angle(other).radians;

--- a/src/base/math/arc.ts
+++ b/src/base/math/arc.ts
@@ -47,7 +47,7 @@ export class Arc {
         const mid_angle = mid.sub(center).angle;
         const end_angle = end.sub(center).angle;
 
-        // calcuate the arc angle
+        // calculate the arc angle
         let arc_angle;
         const start_to_mid = mid_angle.sub(start_angle).normalize();
         const start_to_end = end_angle.sub(start_angle).normalize();
@@ -60,8 +60,8 @@ export class Arc {
             arc_angle = Angle.from_degrees(360).sub(start_to_end);
         }
 
-        // although kicad always create a clockwise arc,
-        // but we can import a counter-clockwise arc from other EDA/CAD using KiCad
+        // although KiCad always creates clockwise arcs, the file may contain
+        // counter-clockwise arcs through imports from other EDA/CAD programs
         let arc_start;
         let direction: ArcDirection;
 

--- a/src/base/math/bbox.ts
+++ b/src/base/math/bbox.ts
@@ -110,7 +110,7 @@ export class BBox {
     }
 
     /**
-     * @returns true if the bbox has a non-zero area
+     * @returns true if the BBox has a non-zero area
      */
     get valid() {
         return (

--- a/src/base/math/camera2.ts
+++ b/src/base/math/camera2.ts
@@ -106,7 +106,7 @@ export class Camera2 {
     }
 
     /**
-     * Apply this camera to a 2d canvas
+     * Apply this camera to a 2D canvas
      *
      * A simple convenience method that sets the canvas's transform to
      * the camera's transformation matrix.

--- a/src/base/math/matrix3.ts
+++ b/src/base/math/matrix3.ts
@@ -88,7 +88,7 @@ export class Matrix3 {
     }
 
     /**
-     * @returns a new matrix representing a 2d orthographic projection
+     * @returns a new matrix representing a 2D orthographic projection
      */
     static orthographic(width: number, height: number): Matrix3 {
         // prettier-ignore
@@ -147,7 +147,7 @@ export class Matrix3 {
     }
 
     /**
-     * Transforms a list of vector by a given matrix, which may be null.
+     * Transforms a list of vectors by a given matrix, which may be null.
      */
     static transform_all(mat: Matrix3 | null, vecs: Vec2[]): Vec2[] {
         if (!mat) {
@@ -237,7 +237,7 @@ export class Matrix3 {
     }
 
     /**
-     * @returns A new matrix representing a 2d translation
+     * @returns A new matrix representing a 2D translation
      */
     static translation(x: number, y: number): Matrix3 {
         // prettier-ignore
@@ -265,7 +265,7 @@ export class Matrix3 {
     }
 
     /**
-     * @returns {Matrix3} A new matrix representing a 2d scale
+     * @returns {Matrix3} A new matrix representing a 2D scale
      */
     static scaling(x: number, y: number): Matrix3 {
         // prettier-ignore
@@ -293,7 +293,7 @@ export class Matrix3 {
     }
 
     /**
-     * @returns A new matrix representing a 2d rotation
+     * @returns A new matrix representing a 2D rotation
      */
     static rotation(angle: AngleLike): Matrix3 {
         const theta = new Angle(angle).radians;

--- a/src/base/web-components/decorators.ts
+++ b/src/base/web-components/decorators.ts
@@ -67,7 +67,7 @@ const default_attribute_converter = {
                 return `${value}`;
             default:
                 throw new Error(
-                    `Can not convert type "${type}" and value "${value} to attribute`,
+                    `Cannot convert type "${type}" and value "${value} to attribute`,
                 );
         }
     },
@@ -81,7 +81,7 @@ const default_attribute_converter = {
                 return value === null ? null : Number(value);
             default:
                 throw new Error(
-                    `Can not convert type "${type}" and value "${value} to attribute`,
+                    `Cannot convert type "${type}" and value "${value} to attribute`,
                 );
         }
     },

--- a/src/base/web-components/html.ts
+++ b/src/base/web-components/html.ts
@@ -94,7 +94,7 @@ function prepare_template_html(
 }
 
 /**
- * Walks through the give DOM tree and replaces placeholders with values.
+ * Walks through the given DOM tree and replaces placeholders with values.
  */
 function apply_values_to_tree(tree: DocumentFragment, values: unknown[]) {
     const walker = document.createTreeWalker(
@@ -143,11 +143,11 @@ function apply_content_value(node: Node | null, text: Text, values: unknown[]) {
         if (!part) {
             continue;
         }
-        // Even parts are text nodes.
+        // Even numbered parts are text nodes.
         if (i % 2 == 0) {
             node.insertBefore(new Text(part), text);
         }
-        // Odd parts are placeholders.
+        // Odd numbered parts are placeholders.
         else {
             for (const value of convert_value_for_content(
                 values[parseInt(part, 10)],
@@ -158,7 +158,7 @@ function apply_content_value(node: Node | null, text: Text, values: unknown[]) {
         }
     }
 
-    // clear the text data instead of removing the node, since removing it will
+    // Clear the text data instead of removing the node, since removing it will
     // break the tree walker.
     text.data = "";
 }

--- a/src/graphics/renderer.ts
+++ b/src/graphics/renderer.ts
@@ -108,7 +108,7 @@ export abstract class Renderer implements IDisposable {
     /**
      * Finish a layer of graphics.
      *
-     * Performs any additional work needed such as tesselation and buffer
+     * Performs any additional work needed such as tessellation and buffer
      * management.
      */
     abstract end_layer(): RenderLayer;

--- a/src/graphics/webgl/renderer.ts
+++ b/src/graphics/webgl/renderer.ts
@@ -95,7 +95,7 @@ export class WebGL2Renderer extends Renderer {
     override clear_canvas() {
         if (this.gl == null) throw new Error("Uninitialized");
 
-        // Upate canvas size and projection matrix if needed
+        // Update canvas size and projection matrix if needed
         this.update_canvas_size();
 
         this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT);

--- a/src/graphics/webgl/vector.ts
+++ b/src/graphics/webgl/vector.ts
@@ -6,7 +6,7 @@
 
 /**
  * Low-level library for efficiently rendering sets of basic geometric
- * primitives using WebGL. Think of it as a really hard to use version
+ * primitives using WebGL. Think of it as a really hard-to-use version
  * of SVG. This is the underlying code used by WebGL2Renderer to actually
  * turn abstract primitives into WebGL stuff.
  *
@@ -16,7 +16,7 @@
  * The core principle here is primitive sets. These sets collect all the data
  * necessary to render *multiple* primitives. Primitive sets are write-once.
  * Call set() with a list of primitive objects to tesselate them and upload
- * their data to the GPU. Use draw() to have the GPU render the tesselated
+ * their data to the GPU. Use draw() to have the GPU render the tessellated
  * geometry. Use dispose() to free GPU resources.
  *
  */
@@ -156,7 +156,7 @@ class Tesselator {
     }
 
     /**
-     * Tesselate a circle into a quad
+     * Tessellate a circle into a quad
      * @returns four points representing the quad
      */
     static tesselate_circle(circle: Circle): [Vec2, Vec2, Vec2, Vec2] {
@@ -172,7 +172,7 @@ class Tesselator {
     }
 
     /**
-     * Tesselate an array of circles into renderable data
+     * Tessellate an array of circles into renderable data
      */
     static tesselate_circles(circles: Circle[]) {
         const vertex_count = circles.length * this.vertices_per_quad;
@@ -377,7 +377,7 @@ export class PolylineSet implements IDisposable {
     }
 
     /**
-     * Tesselate an array of polylines and upload them to the GPU.
+     * Tessellate an array of polylines and upload them to the GPU.
      */
     set(lines: Polyline[]) {
         if (!lines.length) {
@@ -477,7 +477,7 @@ export class PolygonSet implements IDisposable {
     /**
      * Convert an array of triangle vertices to polylines.
      *
-     * This is a helper function for debugging. It allows easily drawing the
+     * This is a helper function for debugging. It allows for easy drawing of the
      * outlines of the results of triangulation.
      *
      */
@@ -497,7 +497,7 @@ export class PolygonSet implements IDisposable {
     }
 
     /**
-     * Tesselate (triangulate) and upload a list of polygons to the GPU.
+     * Tessellate (triangulate) and upload a list of polygons to the GPU.
      */
     set(polygons: Polygon[]) {
         let total_vertex_data_length = 0;
@@ -555,7 +555,7 @@ export class PolygonSet implements IDisposable {
  * GPU, and draw them together. This is conceptually a "layer", all primitives
  * are drawn at the same depth.
  *
- * Like the underlying primitive sets, this is intended to be write once. Once
+ * Like the underlying primitive sets, this is intended to be written to once. Once
  * you call commit() the primitive data is released from working RAM and exists
  * only in the GPU buffers. To modify the data, you'd dispose() of this layer
  * and create a new one.
@@ -636,7 +636,7 @@ export class PrimitiveSet implements IDisposable {
     }
 
     /**
-     * Tesselate all collected primitives and upload their data to the GPU.
+     * Tessellate all collected primitives and upload their data to the GPU.
      */
     commit() {
         if (this.#polygons.length) {

--- a/src/kicad/board.ts
+++ b/src/kicad/board.ts
@@ -1144,7 +1144,7 @@ export class SymbolProperty implements HasUniqueID {
     }
 }
 
-/** Base class for Line, Circle, and others which has 'stroke' property. */
+/** Base class for Line, Circle, and others which have 'stroke' property. */
 class GraphicItem implements HasUniqueID, HasStrokeParams {
     parent?: Footprint | KicadPCB;
     layer: string;

--- a/src/kicad/common.ts
+++ b/src/kicad/common.ts
@@ -447,7 +447,7 @@ export interface HasStrokeParams {
     get stroke_params(): StrokeParams;
 }
 
-/** Items which has netname */
+/** Items which have a netname */
 export interface HasNetName {
     get netname(): string | undefined;
 }

--- a/src/kicad/parser.ts
+++ b/src/kicad/parser.ts
@@ -104,7 +104,7 @@ export const T = {
         return new Color(el[1] / 255, el[2] / 255, el[3] / 255, el[4]);
     },
     /**
-     * Choice one type processor by prefix
+     * Choose a type processor by prefix
      *
      * Example: `choice[("xy", T.vec2), ("color", T.color)]`
      *  - if input is `(xy 1 2)`, use `T.vec2` to parse input
@@ -310,7 +310,7 @@ export const P = {
         return P.expr(name, T.item(item_type, ...args));
     },
     /**
-     * Accepts an expression that describes a 2d vector. For example,
+     * Accepts an expression that describes a 2D vector. For example,
      * ((xy 1 2)) with vec2("xy") would end up with {xy: Vec2(1, 2)}.
      */
     vec2(name: string) {
@@ -356,7 +356,7 @@ export function parse_expr(expr: string | List, ...defs: PropertyDefinition[]) {
 
         if (!acceptable_start_strings.includes(first)) {
             throw new Error(
-                `Expression must start with ${start_def.name} found ${first} in ${expr}`,
+                `Expression must start with ${start_def.name}, but found ${first} in ${expr}`,
             );
         }
 
@@ -380,7 +380,7 @@ export function parse_expr(expr: string | List, ...defs: PropertyDefinition[]) {
 
             if (!def) {
                 log.warn(
-                    `no def for bare element ${element} at position ${n} in expression ${expr}`,
+                    `Bare element ${element} is undefined at position ${n} in expression ${expr}`,
                 );
                 continue;
             }
@@ -395,7 +395,7 @@ export function parse_expr(expr: string | List, ...defs: PropertyDefinition[]) {
 
         if (!def) {
             log.warn(
-                `No def found for element ${element} in expression ${expr}`,
+                `No definition found for element ${element} in expression ${expr}`,
             );
             continue;
         }

--- a/src/kicad/text/font.ts
+++ b/src/kicad/text/font.ts
@@ -465,7 +465,7 @@ export abstract class Font {
 
     /** Breaks text up into words, accounting for markup.
      *
-     * Corresponds to KiCAD's FONT::workbreakMarkup
+     * Corresponds to KiCAD's FONT::wordbreakMarkup
      *
      * As per KiCAD, a word can represent an actual word or a run of text
      * with subscript, superscript, or overbar applied.

--- a/src/kicad/text/glyph.ts
+++ b/src/kicad/text/glyph.ts
@@ -9,7 +9,7 @@ import { Angle, BBox, Vec2 } from "../../base/math";
 /**
  * Glyph abstract base class
  *
- * Shared between stroke and outline fonts, altough outline fonts aren't
+ * Shared between stroke and outline fonts, although outline fonts aren't
  * currently implemented.
  */
 export abstract class Glyph {

--- a/src/kicad/text/lib-text.ts
+++ b/src/kicad/text/lib-text.ts
@@ -125,7 +125,7 @@ export class LibText extends EDAText {
 
     /**
      * Internal utility method for offsetting the text position based on the
-     * horizontal and vertical justifcation.
+     * horizontal and vertical justification.
      */
     normalize_justification(inverse: boolean) {
         let delta = new Vec2(0, 0);
@@ -193,7 +193,7 @@ export class LibText extends EDAText {
     /**
      * Mirrors the text horizontally.
      *
-     * Deals with re-assigning the horizontal justification, as mirroring
+     * Deals with reassigning the horizontal justification, as mirroring
      * left aligned text is the same as changing it to right aligned.
      */
     mirror_horizontally(center: Vec2) {
@@ -217,7 +217,7 @@ export class LibText extends EDAText {
     /**
      * Mirrors the text vertically.
      *
-     * Deals with re-assigning the vertical justification, as mirroring
+     * Deals with reassigning the vertical justification, as mirroring
      * top aligned text is the same as changing it to bottom aligned.
      */
     mirror_vertically(center: Vec2) {

--- a/src/kicad/text/sch-field.ts
+++ b/src/kicad/text/sch-field.ts
@@ -34,8 +34,8 @@ export class SchField extends EDAText {
         return this.text;
     }
 
-    /** Get effective rotation when drawing, taking into the parent position
-     * orientation, and transformation.
+    /** Get effective rotation when drawing, taking into account the parent
+     * position orientation, and transformation.
      */
     get draw_rotation() {
         let this_deg = this.text_angle.degrees;
@@ -95,7 +95,7 @@ export class SchField extends EDAText {
         begin = this.text_angle.rotate_point(begin, pos);
         end = this.text_angle.rotate_point(end, pos);
 
-        // adjust bounding box based on symbol tranform
+        // adjust bounding box based on symbol transform
 
         // Symbols have the y axis direction flipped, so the bounding
         // box must also be flipped.

--- a/src/kicad/text/sch-text.ts
+++ b/src/kicad/text/sch-text.ts
@@ -14,7 +14,7 @@ import { EDAText } from "./eda-text";
  *
  * This class is also used by the LabelPainter and PinPainter, specifically
  * for apply set_spin_style_from_angle. It might be possible to remove this
- * class altogether in favor of just have that method somewhere.
+ * class altogether in favor of just having that method somewhere.
  */
 export class SchText extends EDAText {
     constructor(text: string) {

--- a/src/kicad/text/stroke-font.ts
+++ b/src/kicad/text/stroke-font.ts
@@ -219,7 +219,7 @@ export class StrokeFont extends Font {
             );
         }
 
-        // Note: KiCanvas treats underline and overbar as mututally exclusive,
+        // Note: KiCanvas treats underline and overbar as mutually exclusive,
         // but technically KiCAD can show both at the same time. I wasn't able
         // to find an actual real world case of this.
         if (has_bar) {

--- a/src/kicanvas/elements/common/app.ts
+++ b/src/kicanvas/elements/common/app.ts
@@ -209,7 +209,7 @@ export abstract class KCViewerAppElement<
             </kc-ui-activity-side-bar>` as KCUIActivitySideBarElement;
             resizer = html`<kc-ui-resizer></kc-ui-resizer>`;
         } else {
-            // NO activity bar
+            // No activity bar
             this.#activity_bar = null;
         }
 

--- a/src/kicanvas/elements/kc-board/app.ts
+++ b/src/kicanvas/elements/kc-board/app.ts
@@ -10,7 +10,7 @@ import type { ProjectPage } from "../../project";
 import { KCViewerAppElement } from "../common/app";
 import { KCBoardViewerElement } from "./viewer";
 
-// import dependent elements so they're registered before use.
+// Import dependent elements so they're registered before use.
 import "../common/help-panel";
 import "../common/preferences-panel";
 import "../common/viewer-bottom-toolbar";

--- a/src/kicanvas/elements/kc-schematic/app.ts
+++ b/src/kicanvas/elements/kc-schematic/app.ts
@@ -8,7 +8,7 @@ import { html } from "../../../base/web-components";
 import { KCViewerAppElement } from "../common/app";
 import { KCSchematicViewerElement } from "./viewer";
 
-// import dependent elements so they're registered before use.
+// Import dependent elements so they're registered before use.
 import "./info-panel";
 import "./properties-panel";
 import "./symbols-panel";
@@ -37,7 +37,7 @@ export class KCSchematicAppElement extends KCViewerAppElement<KCSchematicViewerE
             return;
         }
 
-        // Otherwise, selecting the same item twice should show the
+        // Otherwise, selecting the same item twice will show the
         // properties panel.
         this.change_activity("properties");
     }

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -28,7 +28,7 @@ KCUIIconElement.sprites_url = sprites_url;
 
 /**
  * <kc-kicanvas-shell> is the main entrypoint for the standalone KiCanvas
- * application- it's the thing you see when you go to kicanvas.org.
+ * application: It's the thing you see when you go to kicanvas.org.
  *
  * The shell is responsible for managing the currently loaded Project and
  * switching between the different viewer apps (<kc-schematic-app>,
@@ -50,7 +50,7 @@ KCUIIconElement.sprites_url = sprites_url;
 class KiCanvasShellElement extends KCUIElement {
     static override styles = [
         ...KCUIElement.styles,
-        // TODO: Figure out a better way to handle these two styles.
+        // TODO: Find a better way to handle these two styles.
         new CSS(kc_ui_styles),
         new CSS(shell_styles),
     ];

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -51,7 +51,7 @@ export class Project extends EventTarget implements IDisposable {
         await Promise.all(promises);
 
         while (promises.length) {
-            // 'Recursively' resolve all schematics until none are remaining
+            // 'Recursively' resolve all schematics until none remain
             promises = [];
             for (const schematic of this.schematics()) {
                 for (const sheet of schematic.sheets) {
@@ -110,7 +110,7 @@ export class Project extends EventTarget implements IDisposable {
         this.#files_by_name.set(filename, doc);
 
         if (doc instanceof KicadPCB) {
-            // Go ahead and add PCBs to the list of pages. Schematics will
+            // Add PCBs to the list of pages. Schematics will
             // get added during #determine_schematic_hierarchy.
             const page = new ProjectPage(
                 this,
@@ -194,7 +194,7 @@ export class Project extends EventTarget implements IDisposable {
         }
 
         // If we found a root page, we can build out the list of pages by
-        // walking through paths_to_sheet with root as page one.
+        // walking through paths_to_sheet with the root as page one.
         let pages = [];
 
         if (root) {

--- a/src/viewers/base/grid.ts
+++ b/src/viewers/base/grid.ts
@@ -24,12 +24,12 @@ export class GridLOD {
 /**
  * Grid drawing helper
  *
- * The grid is one of few things in KiCanvas that's dynamic- it needs to change
- * depending on the camera's viewport. Since it needs to update when the user
- * is actively moving the camera care has to be taken to avoid performance
+ * The grid is one of only a few things in KiCanvas that's dynamic: It needs
+ * to change depending on the camera's viewport. Since it needs to update when the
+ * user is actively moving the camera, care has to be taken to avoid performance
  * issues due to the amount of geometry that needs to be generated.
  *
- * This grid helper avoid regenerating grid geometry unless necessary. It keeps
+ * This grid helper avoids regenerating grid geometry unless necessary. It keeps
  * track of the last camera bbox it generated geometry for and doesn't
  * regenerate unless the new bbox is outside of that area. It also uses GridLOD
  * to generate less geometry when zoomed out.
@@ -63,7 +63,7 @@ export class Grid {
             }
         }
 
-        // If the camera is too far zoomed out, don't bother drawing the grid.
+        // If the camera is zoomed too far out, don't bother drawing the grid.
         if (!lod) {
             this.reset();
             return;
@@ -77,7 +77,7 @@ export class Grid {
             return;
         }
 
-        // grow the bbox 20% to improve performance of panning.
+        // Grow the bbox 20% to improve performance when panning.
         bbox = bbox.grow(bbox.w * 0.2);
 
         this.#last_grid_lod = lod;

--- a/src/viewers/base/painter.ts
+++ b/src/viewers/base/painter.ts
@@ -12,7 +12,7 @@ import { ViewLayer, ViewLayerSet } from "./view-layers";
 const log = new Logger("kicanvas:project");
 
 /**
- * Base class for all painters responsible for drawing a view items.
+ * Base class for all painters responsible for drawing view items.
  */
 export abstract class ItemPainter {
     /**
@@ -39,7 +39,7 @@ export interface PaintableDocument {
 }
 
 /**
- * Base class for painting a complete document, for example, an entire schematic or board.
+ * Base class for painting a complete document, for example an entire schematic or board.
  */
 export class DocumentPainter {
     #painters: Map<unknown, ItemPainter> = new Map();

--- a/src/viewers/base/view-layers.ts
+++ b/src/viewers/base/view-layers.ts
@@ -10,7 +10,7 @@ import { BBox, Vec2 } from "../../base/math";
 import { Color, RenderLayer } from "../../graphics";
 
 /**
- * Common view layer names across all viewers.
+ * View layer names shared by all viewers.
  */
 export enum ViewLayerNames {
     overlay = ":Overlay",
@@ -21,8 +21,8 @@ export enum ViewLayerNames {
 /**
  * View layers
  *
- * KiCanvas's structure uses view layers to gather schematic or board items.
- * These view layers are used render parts of each item in the correct order
+ * KiCanvas's structure uses view layers to gather schematic and board items.
+ * These view layers are used to render parts of each item in the correct order
  * (back to front) as well as provide bounding box queries.
  *
  * For the board viewer, some layers correspond to physical board layers
@@ -63,12 +63,13 @@ export class ViewLayer implements IDisposable {
     graphics?: RenderLayer;
 
     /**
-     * True is this layer contains interactive items that are findable via
+     * True if this layer contains interactive items that are findable via
      * ViewLayerSet.query_point
      */
     interactive: boolean = false;
 
-    /** A map of board items to bounding boxes
+    /**
+     * A map of board items to bounding boxes
      * A board item can have graphics on multiple layers, the bounding box provided
      * here is only valid for this layer.
      */
@@ -76,7 +77,7 @@ export class ViewLayer implements IDisposable {
 
     /**
      * Create a new Layer.
-     * @param  ayer_set - the LayerSet that this Layer belongs to
+     * @param layer_set - the LayerSet that this Layer belongs to
      * @param name - this layer's name
      * @param visible - controls whether the layer is visible when rendering, may be a function returning a boolean.
      */

--- a/src/viewers/base/viewport.ts
+++ b/src/viewers/base/viewport.ts
@@ -25,7 +25,7 @@ export class Viewport {
 
     /**
      * Create a Scene
-     * @param callback - a callback used to re-draw the viewport when it changes.
+     * @param callback - a callback used to redraw the viewport when it changes.
      */
     constructor(
         public renderer: Renderer,

--- a/src/viewers/board/layers.ts
+++ b/src/viewers/board/layers.ts
@@ -265,7 +265,7 @@ export class LayerSet extends BaseLayerSet {
                 interactive = true;
             }
 
-            // Copper layers require additional virual layers for zones and
+            // Copper layers require additional virtual layers for zones and
             // blind/buried vias. Those are generated here.
             // Zone virtual layers for copper layers require that the referenced
             // copper layer is visible.
@@ -378,7 +378,7 @@ export class LayerSet extends BaseLayerSet {
     }
 
     /**
-     * @yields layers that coorespond to board layers that should be
+     * @yields layers that correspond to board layers that should be
      *      displayed in the layer selection UI
      */
     *in_ui_order() {

--- a/src/viewers/board/painter.ts
+++ b/src/viewers/board/painter.ts
@@ -87,7 +87,7 @@ abstract class GraphicItemPainter extends BoardItemPainter {
         const gap_len = StrokeParams.gap_length(width, stroke_style);
         const dash_len = StrokeParams.dash_length(width, stroke_style);
 
-        // generate line pattern
+        // Generate line pattern
         let line_pattern: number[] = [];
         switch (stroke_style.stroke.type) {
             case "dash":
@@ -110,11 +110,11 @@ abstract class GraphicItemPainter extends BoardItemPainter {
                 ];
                 break;
             default:
-                // unreachable
+                // Unreachable
                 return;
         }
 
-        // draw lines
+        // Draw lines
         let draw_len = 0.0;
         let pattern_index = 0;
         while (draw_len < line_len) {
@@ -147,7 +147,7 @@ abstract class GraphicItemPainter extends BoardItemPainter {
 }
 
 abstract class NetNameItemPainter extends BoardItemPainter {
-    /**  Drawing the netname on `center` in region `region` */
+    // Drawing the netname on `center` in region `region`
     protected draw_net_name(
         net_name: string,
         center: Vec2,
@@ -174,7 +174,7 @@ abstract class NetNameItemPainter extends BoardItemPainter {
         StrokeFont.default().draw(this.gfx, net_name, text_center, text_attr);
     }
 
-    /** Get displayed netname, e.g. "Sheet/Name" -> "Name" */
+    // Get displayed netname, e.g. "Sheet/Name" -> "Name"
     protected static displayed_netname(
         netname: string | undefined,
     ): string | undefined {
@@ -353,7 +353,7 @@ class ViaPainter extends NetNameItemPainter {
 
     layers_for(v: board_items.Via): string[] {
         if (v.layers) {
-            // blind/buried vias have two layers - the start and end layer,
+            // Blind/buried vias have two layers - the start and end layer,
             // and should only be drawn on the layers they're actually on.
             const layers = [];
 
@@ -497,8 +497,8 @@ class PadPainter extends NetNameItemPainter {
                 layers.push(LayerNames.non_plated_holes);
                 break;
             case "smd":
-                // only use pads_front_netname/pads_back_netname in SMD pads
-                // the thru_hole pad uses the pad_holes_netname layer
+                // Only use pads_front_netname/pads_back_netname in SMD pads.
+                // Thru_hole pads uses the pad_holes_netname layer
                 if (layers.includes(LayerNames.pads_front)) {
                     layers.push(LayerNames.pads_front_netname);
                 } else if (layers.includes(LayerNames.pads_back)) {
@@ -546,11 +546,11 @@ class PadPainter extends NetNameItemPainter {
         const net_name = PadPainter.pad_netname(pad);
 
         if (is_netname_layer) {
-            // see also:
+            // See also:
             // https://gitlab.com/kicad/code/kicad/-/blob/master/pcbnew/pcb_painter.cpp#L1379
             const pad_size = PadPainter.get_pad_orth_size(pad);
 
-            // calcuate the maxium text size and rotation angle
+            // Calculate the maximum text size and rotation angle
             let max_width = pad_size.x;
             let max_font_size = pad_size.y;
             let text_rotated = -pad.parent.at.rotation;
@@ -562,7 +562,7 @@ class PadPainter extends NetNameItemPainter {
 
             max_font_size = Math.min(max_font_size, 10);
 
-            // keep the text upright
+            // Keep the text upright
             const pad_rotate = pad.at.rotation;
             while (pad_rotate + text_rotated > 90) {
                 text_rotated -= 180;
@@ -571,17 +571,17 @@ class PadPainter extends NetNameItemPainter {
                 text_rotated += 180;
             }
 
-            // calcuate the offset for pad number and net name if necessary
+            // Calculate the offset for pad number and net name if necessary
             let y_offset_pad_num = 0;
             let y_offset_pad_net = 0;
             if (net_name !== undefined && pad.number !== "") {
-                // 3 can get the better visibility than kicad default value 2.5
+                // 3 gives better visibility than kicad's default value of 2.5
                 max_font_size = max_font_size / 3;
                 y_offset_pad_net = max_font_size / 1.4;
                 y_offset_pad_num = max_font_size / 1.7;
             }
 
-            // keep the text centered
+            // Keep the text centered
             if (pad.drill?.offset) {
                 this.gfx.state.matrix.translate_self(
                     pad.drill.offset.x,
@@ -589,11 +589,11 @@ class PadPainter extends NetNameItemPainter {
                 );
             }
 
-            // apply the text rotation
+            // Apply the text rotation
             const rotate_mat = Matrix3.rotation(Angle.deg_to_rad(text_rotated));
             this.gfx.state.multiply(rotate_mat);
 
-            // render the pad_number
+            // Render the pad_number
             if (pad.number !== "") {
                 this.draw_net_name(
                     pad.number,
@@ -604,7 +604,7 @@ class PadPainter extends NetNameItemPainter {
                 );
             }
 
-            // render netname
+            // Render netname
             if (net_name !== undefined) {
                 this.draw_net_name(
                     net_name,
@@ -675,7 +675,7 @@ class PadPainter extends NetNameItemPainter {
                     break;
                 case "roundrect":
                 case "trapezoid":
-                    // KiCAD approximates rounded rectangle using four line segments
+                    // KiCAD approximates rounded rectangles using four line segments
                     // with their width set to the round radius. Clever bastards.
                     // Since our polylines aren't filled, we'll add both a polygon
                     // and a polyline.
@@ -773,9 +773,9 @@ class PadPainter extends NetNameItemPainter {
         this.gfx.state.pop();
     }
 
-    /** Get displayed netname for a pad, if it's no_connect, return "X" */
+    // Get displayed netname for a pad, if it's no_connect, return "X"
     private static pad_netname(pad: board_items.Pad): string | undefined {
-        // display "X" for no_connect pads
+        // Display "X" for no_connect pads
         // https://gitlab.com/kicad/code/kicad/-/blob/master/pcbnew/pcb_painter.cpp#L1305
         if (pad.pintype !== undefined && pad.pintype.includes("no_connect")) {
             return "X";
@@ -784,13 +784,13 @@ class PadPainter extends NetNameItemPainter {
         return PadPainter.displayed_netname(pad.netname);
     }
 
-    /** Get pad outline size */
+    // Get pad outline size
     private static get_pad_orth_size(pad: board_items.Pad): Vec2 {
         const pad_size = pad.size.copy();
 
         const obj_angle = pad.parent.at.rotation + 36000;
 
-        // swap x, y if pad is not 0 deg or 180 deg
+        // Swap x with y if pad is not 0 deg or 180 deg
         if (obj_angle % 180 !== 0) {
             [pad_size.x, pad_size.y] = [pad_size.y, pad_size.x];
         }
@@ -934,7 +934,7 @@ class PropertyTextPainter extends BoardItemPainter {
         edatext.attributes.color = layer.color;
         edatext.attributes.keep_upright = !t.at.unlocked;
 
-        // keep the text upright if needed
+        // Keep the text upright if needed
         if (edatext.attributes.keep_upright) {
             while (edatext.text_angle.degrees > 90) {
                 edatext.text_angle.degrees -= 180;
@@ -945,7 +945,7 @@ class PropertyTextPainter extends BoardItemPainter {
         }
 
         // Looks like the rotation angle for KiCad's symbol attribute rendering
-        // is standalone, so we need to sub it from parent's rotation angle.
+        // is standalone, so we need to subtract it from its parent's rotation angle.
         if (t.parent) {
             const rot = t.parent.at.rotation;
             edatext.text_angle.degrees -= rot;

--- a/src/viewers/schematic/layers.ts
+++ b/src/viewers/schematic/layers.ts
@@ -18,22 +18,22 @@ export enum LayerNames {
     interactive = ":Interactive",
     // DNP and other marks.
     marks = ":Marks",
-    // reference, value, other symbol fields
+    // Reference, value, other symbol fields
     symbol_field = ":Symbol:Field",
-    // hierarchical, global, and local labels
+    // Hierarchical, global, and local labels
     label = ":Label",
-    // regular junctions, bus junctions, no connects
+    // Regular junctions, bus junctions, no connects
     junction = ":Junction",
-    // wires and buses
+    // Wires and buses
     wire = ":Wire",
-    // symbol outlines, pin names, pin numbers
+    // Symbol outlines, pin names, pin numbers
     symbol_foreground = ":Symbol:Foreground",
     // Text, rectangles, etc. not inside of symbols.
     notes = ":Notes",
     bitmap = ":Bitmap",
-    // symbol pins
+    // Symbol pins
     symbol_pin = ":Symbol:Pin",
-    // symbol body fill
+    // Symbol body fill
     symbol_background = ":Symbol:Background",
     drawing_sheet = BaseLayerNames.drawing_sheet,
     grid = BaseLayerNames.grid,

--- a/src/viewers/schematic/painter.ts
+++ b/src/viewers/schematic/painter.ts
@@ -430,7 +430,7 @@ class PropertyPainter extends SchematicItemPainter {
         ]);
 
         if (layer.name == LayerNames.interactive) {
-            // drawing text is expensive, just draw the bbox for the interactive layer.
+            // Drawing text is expensive, just draw the bbox for the interactive layer.
             this.gfx.line(new Polyline(Array.from(bbox_pts), 0.1, Color.white));
         } else {
             this.gfx.state.push();

--- a/src/viewers/schematic/painters/base.ts
+++ b/src/viewers/schematic/painters/base.ts
@@ -30,9 +30,9 @@ export abstract class SchematicItemPainter extends ItemPainter {
     }
 
     protected dim_color(color: Color) {
-        // See SCH_PAINTER::getRenderColor, this desaturates the color and
+        // See SCH_PAINTER::getRenderColor.  This desaturates the color and
         // mixes it 50% with the background color. While you might think 50%
-        // alpha would be fine, it ends up showing the grid and other stuff
+        // alpha would work fine, it ends up showing the grid and other stuff
         // behind it.
         color = color.desaturate();
         return color.mix(this.theme.background, 0.5);

--- a/src/viewers/schematic/painters/label.ts
+++ b/src/viewers/schematic/painters/label.ts
@@ -14,8 +14,8 @@ import { SchematicItemPainter } from "./base";
 /**
  * Implements KiCAD rendering logic for net, global, and hierarchical labels.
  *
- * This is similar in scope to the SymbolPin, EDAText class and its children,
- * it's designed to recreate KiCAD's behavior as closely as possible.
+ * This is similar in scope to the SymbolPin, EDAText class and its children.
+ * It's designed to recreate KiCAD's behavior as closely as possible.
  *
  * This logic is adapted from:
  * - SCH_LABEL_BASE
@@ -155,7 +155,7 @@ export class GlobalLabelPainter extends LabelPainter {
         let vert = text_height * 0.0715;
 
         if (["input", "bidirectional", "tri_state"].includes(label.shape)) {
-            // accommodate triangular shaped tail
+            // Accommodate triangular shaped tail
             horz += text_height * 0.75;
         }
 

--- a/src/viewers/schematic/painters/pin.ts
+++ b/src/viewers/schematic/painters/pin.ts
@@ -20,11 +20,11 @@ import { SchematicItemPainter } from "./base";
 /**
  * Implements KiCAD rendering logic for symbol pins.
  *
- * This is similar in scope to the EDAText class and its children, it's
+ * This is similar in scope to the EDAText class and its children.  It's
  * designed to recreate KiCAD's behavior as closely as possible.
  *
  * The logic here is based a few small bits of LIB_PIN and EDA_ITEM, with the
- * ast majority adapted from SCH_PAINTER::draw( const LIB_PIN, ...) - which is
+ * vast majority adapted from SCH_PAINTER::draw( const LIB_PIN, ...), which is
  * a massive method at over 400 lines!
  *
  */
@@ -520,7 +520,7 @@ export const PinLabelInternals = {
     },
 
     /**
-     * Places a label inside the symbol body- or to put it another way,
+     * Places a label inside the symbol body.  Or to put it another way,
      * places it to the left side of a pin that's on the right side of a symbol
      */
     place_inside(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "moduleResolution": "bundler",
         // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
         "experimentalDecorators": true,
-        "useDefineForClassFields": false, // required to use experimental decorators
+        "useDefineForClassFields": false, // Required to use experimental decorators
         /* Modules */
         "module": "es2022" /* Specify what module code is generated. */,
         "allowImportingTsExtensions": true,


### PR DESCRIPTION
Fixed spelling misteaks.
Fixed grammar errors.
Changed "tesselate" to "tessellate" in comments (left code unchanged) Replaced 2d with 2D in some places.
Changed "can not" to "cannot".
Clarified meaning of some comments.
Capitalized first letter of some comment strings, to be consistent. Changed some single-line comments from /* */ to //.