### PR TITLE
Switch "KiCAD" strings (and variants) to "KiCad".

### DIFF
--- a/.github/ISSUE_TEMPLATE/my-file-looks-wrong--.md
+++ b/.github/ISSUE_TEMPLATE/my-file-looks-wrong--.md
@@ -10,6 +10,6 @@ assignees: ''
 <!-- Please include:
 
 - The file you're trying to view. If you don't want the file to be public, let us know and we'll arrange for you to send it privately.
-- A screenshot of the file in KiCAD
+- A screenshot of the file in KiCad
 - A screenshot of the file in KiCanvas
 - A description of the issue -->

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -31,7 +31,7 @@ This project contains copies or makes use of other works. These works and their 
 license and terms are:
 
 - Earcut by Mapbox, licensed under the ISC license. Retrived from https://github.com/mapbox/earcut.
-- Newstroke by Vladimir Uryvaev, Lingdong Huang, Adobe, and KiCAD contributors. Originally licensed under Creative Commons CC0 1.0, amended with an MIT-like license, and utilizes glyphs that are licensed under the SIL Open Font License Version 1.1.
+- Newstroke by Vladimir Uryvaev, Lingdong Huang, Adobe, and KiCad contributors. Originally licensed under Creative Commons CC0 1.0, amended with an MIT-like license, and utilizes glyphs that are licensed under the SIL Open Font License Version 1.1.
 - Material Symbols by Google, licensed under the Apache License, Version 2.0. Retrieved from https://github.com/google/material-design-icons.
 - Nunito by Vernon Adams, Manvel Shmavonyan, licensed under the Open Font License. Retrieved from https://fonts.google.com/specimen/Nunito/about
 - Bellota by Kemie Guaida, licensed under the Open Font License. Retrieved from https://fonts.google.com/specimen/Bellota/about

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KiCanvas
 
-[KiCanvas] is an **interactive**, **browser-based** viewer for [KiCAD] schematics and boards. You can try it out for yourself at https://kicanvas.org.
+[KiCanvas] is an **interactive**, **browser-based** viewer for [KiCad] schematics and boards. You can try it out for yourself at https://kicanvas.org.
 
 https://user-images.githubusercontent.com/250995/233475339-43c89a26-c825-4999-9d0a-7bde690c96ca.mp4
 
@@ -11,7 +11,7 @@ You can also use KiCanvas on your own websites using the [embedding API]. It's w
 KiCanvas is developed by [Thea Flowers](https://thea.codes) with financial support from her [sponsors].
 
 [KiCanvas]: https://kicanvas.org
-[KiCAD]: https://kicad.org
+[KiCad]: https://kicad.org
 [file an issue]: https://github.com/theacodes/kicanvas/issues/new/choose
 [embedding API]: https://kicanvas.org/embedding
 [TypeScript]: https://typescript.dev
@@ -30,8 +30,8 @@ KiCanvas is very early in its development and there's a ton of stuff that hasn't
 
 In general, please check the [GitHub issues] page before filing new issues. Some high-level things that we know won't work:
 
-- Any KiCAD 5 files, KiCanvas can only parse files from KiCAD 6 and later.
-- Some KiCAD 7 features might not be fully implemented, such as custom fonts in schematics.
+- Any KiCad 5 files, KiCanvas can only parse files from KiCad 6 and later.
+- Some KiCad 7 features might not be fully implemented, such as custom fonts in schematics.
 - Browsers other than desktop Chrome, Firefox, and Safari may run into issues, as we aren't currently running automated tests against other browsers. We welcome issues related to browser compatibility, just make sure it hasn't already been reported.
 
 [GitHub issues]: https://github.com/theacodes/kicanvas/issues

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -17,9 +17,9 @@ KiCanvas notably does not have any runtime dependencies. Everything it needs to 
 KiCanvas's source code under `./src` is organized into the following:
 
 - `base` contains generic, widely applicable utilities for working with JavaScript, TypeScript, the DOM, and math. These are the sort of things you'd use across multiple, unrelated projects.
-- `kicad` contains the KiCAD data layer and text layout implementation. This is where parsers for KiCAD files and associated models live.
+- `kicad` contains the KiCad data layer and text layout implementation. This is where parsers for KiCad files and associated models live.
 - `graphics` contains the rendering engine. It is somewhat generic- it handles rendering primitives such as lines, circles, and polygons, but is also tailored to KiCanvas's needs in specific ways.
-- `viewers` contains classes that implement viewers for different KiCAD documents. Viewers handle creating geometry using "Painters" and managing "Layers" for the renderer to draw. Viewers do not provide a user interface on their own, they're designed with high-level APIs that let various user interface elements control the viewer.
+- `viewers` contains classes that implement viewers for different KiCad documents. Viewers handle creating geometry using "Painters" and managing "Layers" for the renderer to draw. Viewers do not provide a user interface on their own, they're designed with high-level APIs that let various user interface elements control the viewer.
 - `kc-ui` contains generic, low-level web components used to build KiCanvas's user interface. Elements in here are generic enough to be re-used in other projects, but may be slightly tailored to KiCanvas's needs. For example, `<kc-ui-button>` and `<kc-ui-icon>`.
 - `kicanvas` contains the KiCanvas application and its elements. Elements here implement KiCanvas functionality, such as `<kc-project-panel>` and `<kc-symbols-panel>`.
 

--- a/docs/docs/embedding.md
+++ b/docs/docs/embedding.md
@@ -8,7 +8,7 @@
 
     KiCanvas is in **alpha**. This is a proposed API with an incomplete implementation. Everything here is subject to change and you should be cautious if using it on your own web page.
 
-The `<kicanvas-embed>` HTML element embeds one or more KiCAD documents onto the page:
+The `<kicanvas-embed>` HTML element embeds one or more KiCad documents onto the page:
 
 ```html
 <kicanvas-embed src="my-schematic.kicad_sch"></kicanvas-embed>
@@ -99,7 +99,7 @@ You can switch between the displayed files using the project panel on the right 
 
 ### Inline source
 
-This example shows how to use `<kicanvas-source>` along with inline KiCAD data. In this case, it's a symbol copied from a schematic and pasted into the HTML source:
+This example shows how to use `<kicanvas-source>` along with inline KiCad data. In this case, it's a symbol copied from a schematic and pasted into the HTML source:
 
 ```html
 <kicanvas-embed>
@@ -154,7 +154,7 @@ This example shows how to use `<kicanvas-source>` along with inline KiCAD data. 
     - `nohelp` - don't show the help panel. ⚠️
 - `src` - the URL of the document to embed. If you want to show multiple documents within a single viewer, you can use multiple child `<kicanvas-source>` elements.
 - `type` - when providing the file source inline, this explicitly sets the file type. If not specified, KiCanvas will attempt to determine the type automatically. If specified, it should be one of `schematic`, `board`, `project`, or `worksheet`.
-- `name` - when providing the file source inline, this explicitly sets the file name. This is typically only necessary when there are multiple files within a project, as KiCAD uses the file name to link schematic sheets, drawing sheets, and PCBs together. If unspecified, KiCanvas will generate a file name like `inline_0.kicad_sch`.
+- `name` - when providing the file source inline, this explicitly sets the file name. This is typically only necessary when there are multiple files within a project, as KiCad uses the file name to link schematic sheets, drawing sheets, and PCBs together. If unspecified, KiCanvas will generate a file name like `inline_0.kicad_sch`.
 - `theme` - sets the color theme to use, valid values are `kicad` and `witchhazel`. ⚠️
 - `zoom` - sets the initial view into the document. ⚠️
     - `objects` - zooms to show all visible objects (default). ⚠️

--- a/docs/docs/home.md
+++ b/docs/docs/home.md
@@ -1,6 +1,6 @@
 # KiCanvas
 
-[KiCanvas] is an **interactive**, **browser-based** viewer for [KiCAD] schematics and boards. You can try it out for yourself at [kicanvas.org](https://kicanvas.org).
+[KiCanvas] is an **interactive**, **browser-based** viewer for [KiCad] schematics and boards. You can try it out for yourself at [kicanvas.org](https://kicanvas.org).
 
 <video src="https://user-images.githubusercontent.com/250995/233475339-43c89a26-c825-4999-9d0a-7bde690c96ca.mp4" controls="true"></video>
 
@@ -13,7 +13,7 @@ You can also use KiCanvas on your own websites using the [embedding API](embeddi
 KiCanvas is developed by [Thea Flowers](https://thea.codes) with financial support from her [sponsors].
 
 [KiCanvas]: http://kicanvas.org/home/
-[KiCAD]: https://kicad.org
+[KiCad]: https://kicad.org
 [file an issue]: https://github.com/theacodes/kicanvas/issues/new/choose
 [TypeScript]: https://typescript.dev
 [Canvas]: https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API
@@ -25,8 +25,8 @@ KiCanvas is developed by [Thea Flowers](https://thea.codes) with financial suppo
 
 In general, please check the [GitHub issues] page before filing new issues. Some high-level things that we known won't work:
 
-- Any KiCAD 5 files, KiCanvas can only parse files from KiCAD 6 and later.
-- Some KiCAD 7 features might not be fully implemented, such as custom fonts in schematics.
+- Any KiCad 5 files, KiCanvas can only parse files from KiCad 6 and later.
+- Some KiCad 7 features might not be fully implemented, such as custom fonts in schematics.
 - Browsers other than desktop Chrome, Firefox, and Safari may run into issues, as we aren't currently running automated tests against other browsers. We welcome issues related to browser compatibility, just make sure it hasn't already been reported.
 
 [GitHub issues]: https://github.com/theacodes/kicanvas/issues
@@ -43,15 +43,15 @@ Yes, but, it's all very early stages. See [embedding](embedding.md) for more det
 
 > Do I need to use a plugin to show my files in KiCanvas
 
-Nope, not at all. KiCanvas reads KiCAD files directly.
+Nope, not at all. KiCanvas reads KiCad files directly.
 
-> Are you going to support KiCAD 7 features? Custom fonts?
+> Are you going to support KiCad 7 features? Custom fonts?
 
-Yes. I'm actively working on bringing KiCanvas up to parity with KiCanvas 7, including custom fonts. For the time being, KiCAD 7 files should parse and load in KiCanvas, however, KiCanvas may not render some KiCAD 7 features correctly.
+Yes. I'm actively working on bringing KiCanvas up to parity with KiCad 7, including custom fonts. For the time being, KiCad 7 files should parse and load in KiCanvas, however, KiCanvas may not render some KiCad 7 features correctly.
 
 > Will KiCanvas support something like [InteractiveHtmlBom]?
 
-Yes, KiCanvas will eventually let you view PCBs in "Assembly guide" mode. This won't require any extra KiCAD plugins or anything.
+Yes, KiCanvas will eventually let you view PCBs in "Assembly guide" mode. This won't require any extra KiCad plugins or anything.
 
 [InteractiveHtmlBom]: https://github.com/openscopeproject/InteractiveHtmlBom
 
@@ -59,15 +59,15 @@ Yes, KiCanvas will eventually let you view PCBs in "Assembly guide" mode. This w
 
 Because KiCanvas's developer-facing APIs for embedding and parsing are not yet ready. I don't want to publish it only to immediately break users as I rapidly iterate and change things. These developer APIs are my next priority after getting rendering to a good state. Stay tuned.
 
-> Why don't you support KiCAD 5 files?
+> Why don't you support KiCad 5 files?
 
-KiCAD 5 files are a completely different format from V6 and onwards. Implementing parsers for that format would take a lot of time and I'm not interested in doing it.
+KiCad 5 files are a completely different format from V6 and onwards. Implementing parsers for that format would take a lot of time and I'm not interested in doing it.
 
 > Why didn't you use [x] library/framework?
 
 From the outset I wanted KiCanvas to be dependency-free. KiCanvas should not pull in any additional libraries that may interfere with the page its embedding on.
 
-> Lol are you going to port all of KiCAD to the browser?
+> Lol are you going to port all of KiCad to the browser?
 
 No, KiCanvas is explicitly read-only and due to that assumption being baked in it wouldn't serve as a good base for a browser-based editor.
 

--- a/docs/docs/license.md
+++ b/docs/docs/license.md
@@ -34,7 +34,7 @@ derivative works.
 This project contains copies or makes use of other works. These works and their respective license and terms are:
 
 - Earcut by Mapbox, licensed under the ISC license. Retrieved from https://github.com/mapbox/earcut.
-- Newstroke by Vladimir Uryvaev, Lingdong Huang, Adobe, and KiCAD contributors. Originally licensed under Creative Commons CC0 1.0, amended with an MIT-like license, and utilizes glyphs that are licensed under the SIL Open Font License Version 1.1.
+- Newstroke by Vladimir Uryvaev, Lingdong Huang, Adobe, and KiCad contributors. Originally licensed under Creative Commons CC0 1.0, amended with an MIT-like license, and utilizes glyphs that are licensed under the SIL Open Font License Version 1.1.
 - Material Symbols by Google, licensed under the Apache License, Version 2.0. Retrieved from https://github.com/google/material-design-icons.
 - Nunito by Vernon Adams, Manvel Shmavonyan, licensed under the Open Font License. Retrieved from https://fonts.google.com/specimen/Nunito/about
 - Bellota by Kemie Guaida, licensed under the Open Font License. Retrieved from https://fonts.google.com/specimen/Bellota/about

--- a/docs/docs/roadmap.md
+++ b/docs/docs/roadmap.md
@@ -9,14 +9,14 @@ Here's a non-exhaustive roadmap:
     - [x] kicad_pcb parser
     - [x] kicad_wks parser
     - [x] kicad_pro parser
-    - [x] Rendering KiCAD 6 schematics
-    - [x] Rendering KiCAD 6 boards
-    - [x] Rendering KiCAD 6 text
+    - [x] Rendering KiCad 6 schematics
+    - [x] Rendering KiCad 6 boards
+    - [x] Rendering KiCad 6 text
     - [x] Rendering worksheets
     - [x] Loading hierarchical schematics
-    - [x] Rendering KiCAD 7 schematics
-    - [x] Rendering KiCAD 7 boards
-    - [x] Rendering KiCAD 7 text
+    - [x] Rendering KiCad 7 schematics
+    - [x] Rendering KiCad 7 boards
+    - [x] Rendering KiCad 7 text
     - [ ] Rendering bitmap objects
     - [ ] Rendering custom fonts
 - [ ] Viewer functionality
@@ -36,7 +36,7 @@ Here's a non-exhaustive roadmap:
     - [x] Board object visibility controls
     - [ ] Board trace selection
     - [ ] Board zone selection
-    - [ ] Copy selected item for pasting into KiCAD
+    - [ ] Copy selected item for pasting into KiCad
     - [x] Theming
     - [ ] Onion view
 - [x] Standalone web application (kicanvas.org)

--- a/docs/overrides/standalone.html
+++ b/docs/overrides/standalone.html
@@ -4,7 +4,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="Interactive KiCAD file viewer" />
+        <meta name="description" content="Interactive KiCad file viewer" />
         <link rel="shortcut icon" sizes="192x192" href="/icon.png" />
         <link rel="apple-touch-icon" sizes="192x192" href="/icon.png" />
         <link rel="stylesheet" href="styles/standalone.css" />

--- a/scripts/build-font.js
+++ b/scripts/build-font.js
@@ -5,9 +5,9 @@
 */
 
 /**
- * Transforms KiCAD's newstroke font into a format KiCanvas can use.
+ * Transforms KiCad's newstroke font into a format KiCanvas can use.
  *
- * Newstroke is distributed as a .cpp file and a old-format KiCAD library,
+ * Newstroke is distributed as a .cpp file and a old-format KiCad library,
  * this script transforms it into a .ts file so it can be easily imported
  * into KiCanvas
  *

--- a/src/base/color.ts
+++ b/src/base/color.ts
@@ -119,7 +119,7 @@ export class Color {
     }
 
     desaturate() {
-        // From KiCAD's COLOR4D::Desaturate
+        // From KiCad's COLOR4D::Desaturate
         if (this.r == this.g && this.r == this.b) {
             return this;
         }

--- a/src/base/math/angle.ts
+++ b/src/base/math/angle.ts
@@ -32,7 +32,7 @@ export class Angle {
     /** Round degrees to two decimal places
      *
      * A lot of math involving angles is done with degrees to two decimal places
-     * instead of radians to match KiCAD's behavior and to avoid floating point
+     * instead of radians to match KiCad's behavior and to avoid floating point
      * nonsense.
      */
     static round(degrees: number): number {

--- a/src/base/math/arc.ts
+++ b/src/base/math/arc.ts
@@ -159,7 +159,7 @@ export class Arc {
             [end, start] = [start, end];
         }
 
-        // TODO: Pull KiCAD's logic for this, since it adds more segments the
+        // TODO: Pull KiCad's logic for this, since it adds more segments the
         // larger the arc is.
         for (let theta = start; theta < end; theta += Math.PI / 32) {
             points.push(
@@ -239,7 +239,7 @@ export class Arc {
 /**
  * Figure out the center point of a circular arc given three points along the circle.
  *
- * Ported from KiCAD's KiMATH trigo
+ * Ported from KiCad's KiMATH trigo
  */
 function arc_center_from_three_points(start: Vec2, mid: Vec2, end: Vec2): Vec2 {
     const sqrt_1_2 = Math.SQRT1_2;

--- a/src/base/math/vec2.ts
+++ b/src/base/math/vec2.ts
@@ -96,7 +96,7 @@ export class Vec2 {
     }
 
     /**
-     * KiCAD has to be weird about this, ofc.
+     * KiCad has to be weird about this, ofc.
      */
     get kicad_angle(): Angle {
         // See explicit EDA_ANGLE( const VECTOR2D& aVector )

--- a/src/kicad/board.ts
+++ b/src/kicad/board.ts
@@ -1169,7 +1169,7 @@ class GraphicItem implements HasUniqueID, HasStrokeParams {
         const plot_cfg = pcb?.setup?.pcbplotparams;
 
         // dashed_line_gap_ratio = 3, dashed_line_dash_ratio = 12
-        // is the default values from kicad
+        // is the default values from KiCad
         return {
             stroke: this.stroke,
             dashed_line_gap_ratio: plot_cfg?.dashed_line_gap_ratio ?? 3,

--- a/src/kicad/common.ts
+++ b/src/kicad/common.ts
@@ -287,7 +287,7 @@ export class Font {
                 ),
             );
 
-            // Note: KiCAD saves height as the first number and width as the
+            // Note: KiCad saves height as the first number and width as the
             // second. I have no fucking idea why they did that.
             [this.size.x, this.size.y] = [this.size.y, this.size.x];
         }

--- a/src/kicad/default_drawing_sheet.kicad_wks
+++ b/src/kicad/default_drawing_sheet.kicad_wks
@@ -14,7 +14,7 @@
   (tbtext "A" (name "") (pos 1 25 rtcorner) (font (size 1.3 1.3)) (justify center) (repeat 100) (incry 50))
   (tbtext "Date: ${ISSUE_DATE}" (name "") (pos 87 6.9))
   (line (name "") (start 110 5.5) (end 2 5.5))
-  (tbtext "${KICAD_VERSION}" (name "") (pos 109 4.1) (comment "Kicad version"))
+  (tbtext "${KICAD_VERSION}" (name "") (pos 109 4.1) (comment "KiCad version"))
   (line (name "") (start 110 8.5) (end 2 8.5))
   (tbtext "Rev: ${REVISION}" (name "") (pos 24 6.9) (font bold))
   (tbtext "Size: ${PAPER}" (name "") (pos 109 6.9) (comment "Paper format name"))

--- a/src/kicad/drawing-sheet.ts
+++ b/src/kicad/drawing-sheet.ts
@@ -121,7 +121,7 @@ export class DrawingSheet {
                 // Sheet path (hierarchical path)
                 return "/";
             case "KICAD_VERSION":
-                // KiCAD Version
+                // KiCad Version
                 return "KiCanvas Alpha";
         }
         return this.document?.resolve_text_var(name);

--- a/src/kicad/project-settings.ts
+++ b/src/kicad/project-settings.ts
@@ -9,7 +9,7 @@ import { merge } from "../base/object";
 /**
  * Holds configuration and settings from a .kicad_pro file.
  *
- * See KiCAD's PROJECT_FILE class
+ * See KiCad's PROJECT_FILE class
  */
 export class ProjectSettings {
     public board: BoardSettings = new BoardSettings();

--- a/src/kicad/schematic.ts
+++ b/src/kicad/schematic.ts
@@ -478,7 +478,7 @@ export class Bezier extends GraphicItem {
     pts: Vec2[];
 
     constructor(expr: Parseable, parent?: LibSymbol | SchematicSymbol) {
-        /* TODO: this was added in KiCAD 7 */
+        /* TODO: this was added in KiCad 7 */
         super(parent);
         Object.assign(
             this,
@@ -661,7 +661,7 @@ export class TextBox extends GraphicItem {
     effects = new Effects();
 
     constructor(expr: Parseable, parent?: LibSymbol | SchematicSymbol) {
-        /* TODO: This was added in KiCAD 7 */
+        /* TODO: This was added in KiCad 7 */
         super(parent);
         Object.assign(
             this,
@@ -957,7 +957,7 @@ export class LibSymbol {
     }
 
     get unit(): number {
-        // KiCAD encodes the symbol unit into the name, for example,
+        // KiCad encodes the symbol unit into the name, for example,
         // MCP6001_1_1 is unit 1 and MCP6001_2_1 is unit 2.
         // Unit 0 is common to all units.
         // See SCH_SEXPR_PARSER::ParseSymbol.
@@ -970,7 +970,7 @@ export class LibSymbol {
     }
 
     get style(): number {
-        // KiCAD "De Morgan" body styles are indicated with a number greater
+        // KiCad "De Morgan" body styles are indicated with a number greater
         // than one at the end of the symbol name.
         // MCP6001_1_1 is the normal body and and MCP6001_1_2 is the alt style.
         // Style 0 is common to all styles.

--- a/src/kicad/text/eda-text.ts
+++ b/src/kicad/text/eda-text.ts
@@ -11,12 +11,12 @@ import { StrokeFont } from "./stroke-font";
 
 /** Primary text mixin
  *
- * KiCAD uses EDA_TEXT as a sort of grab-bag of various things needed to render
+ * KiCad uses EDA_TEXT as a sort of grab-bag of various things needed to render
  * text across both Eeschema and Pcbnew. There is a lot of meandering code
  * because it has mostly been worked on piecemeal over the years, so there's
  * some stuff that is a little weird and some code that does almost the same
  * thing as other code. I've done my best to keep the structure clean while
- * carefully matching KiCAD's behavior, but it's still a lot to wrap your
+ * carefully matching KiCad's behavior, but it's still a lot to wrap your
  * head around.
  *
  * Note: Just like the underlying Font class, this all expects
@@ -30,7 +30,7 @@ export class EDAText {
     /**
      * Apply "effects" parsed from schematic or board files.
      *
-     * KiCAD uses Effects to encapsulate all of the various text
+     * KiCad uses Effects to encapsulate all of the various text
      * options, this translates it into TextAttributes used by Font.
      */
     apply_effects(effects: Effects) {
@@ -48,7 +48,7 @@ export class EDAText {
     /**
      * Apply "at" parsed from schematic or board files.
      *
-     * KiCAD uses At to encapsulate both position and rotation. How this is
+     * KiCad uses At to encapsulate both position and rotation. How this is
      * actually applied various based on the actual text item.
      */
     apply_at(at: At) {
@@ -292,7 +292,7 @@ function get_normal_thickness(text_width: number): number {
 
 /** Prevents text from being too thick and overlapping
  *
- * As per KiCAD's Clamp_Text_PenSize, this limits normal text to
+ * As per KiCad's Clamp_Text_PenSize, this limits normal text to
  * 18% and bold text to 25%.
  */
 function clamp_thickness(

--- a/src/kicad/text/font.ts
+++ b/src/kicad/text/font.ts
@@ -14,13 +14,13 @@ import { Markup, MarkupNode } from "./markup";
  * Defines the interface and common methods used for both
  * stroke fonts and (eventually) outline fonts.
  *
- * Note: KiCAD always passes any coordinates or sizes in scaled internal units
+ * Note: KiCad always passes any coordinates or sizes in scaled internal units
  * (1 UI = 1 nm for PCBNew and 1 UI = 100 nm for EESchema). That is, 1.27 mm is
- * represented as 12700 IU for EESchema and 1270000 IU for PCBNew. See KiCAD's
+ * represented as 12700 IU for EESchema and 1270000 IU for PCBNew. See KiCad's
  * EDA_UNITS for more details. Importantly, this means this code will likely
  * not work as expected if you use unscaled units!
  *
- * This is largely adapted from KiCAD's KIFONT::FONT base class and beaten
+ * This is largely adapted from KiCad's KIFONT::FONT base class and beaten
  * to death with a TypeScript hammer.
  */
 export abstract class Font {
@@ -54,7 +54,7 @@ export abstract class Font {
     /**
      * Computes the width and height of a single line of marked up text.
      *
-     * Corresponds to KiCAD's FONT::StringBoundaryLimits
+     * Corresponds to KiCad's FONT::StringBoundaryLimits
      *
      * Used by EDAText.get_text_box(), which, inexplicably, doesn't use
      * get_line_bbox() for what I can only assume is historical reasons.
@@ -94,7 +94,7 @@ export abstract class Font {
      * Adds additional line breaks to the given marked up text in order to limit
      * the overall width to the given column_width.
      *
-     * Note: this behaves like KiCAD's FONT::LinebreakText in that it only
+     * Note: this behaves like KiCad's FONT::LinebreakText in that it only
      * breaks on spaces, it does not break within superscript, subscript, or
      * overbar, and it doesn't bother with justification.
      *
@@ -191,7 +191,7 @@ export abstract class Font {
      *
      * Multitext text must be split before calling this function.
      *
-     * Corresponds to KiCAD's Font::DrawSingleLineText
+     * Corresponds to KiCad's Font::DrawSingleLineText
      *
      * Used by draw()
      */
@@ -241,7 +241,7 @@ export abstract class Font {
     /**
      * Computes the bounding box for a single line of text.
      *
-     * Corresponds to KiCAD's FONT::boundingBoxSingleLine
+     * Corresponds to KiCad's FONT::boundingBoxSingleLine
      *
      * Used by get_line_positions() and draw()
      */
@@ -361,7 +361,7 @@ export abstract class Font {
     /**
      * Converts marked up text to glyphs
      *
-     * Corresponds to KiCAD's FONT::drawMarkup, which doesn't actually draw,
+     * Corresponds to KiCad's FONT::drawMarkup, which doesn't actually draw,
      * just converts to glyphs.
      *
      * Used by string_boundary_limits(), draw_single_line_text(), and
@@ -465,9 +465,9 @@ export abstract class Font {
 
     /** Breaks text up into words, accounting for markup.
      *
-     * Corresponds to KiCAD's FONT::wordbreakMarkup
+     * Corresponds to KiCad's FONT::wordbreakMarkup
      *
-     * As per KiCAD, a word can represent an actual word or a run of text
+     * As per KiCad, a word can represent an actual word or a run of text
      * with subscript, superscript, or overbar applied.
      *
      * Used by SCH_TEXTBOX & PCB_TEXTBOX

--- a/src/kicad/text/glyph.ts
+++ b/src/kicad/text/glyph.ts
@@ -46,7 +46,7 @@ export class StrokeGlyph extends Glyph {
         mirror: boolean,
         origin: Vec2,
     ): StrokeGlyph {
-        // Note: our bbox calculation differs from KiCAD's, however,
+        // Note: our bbox calculation differs from KiCad's, however,
         // when I wrote this it seems to be consistent in terms of final
         // outcome.
         const bb = this.bbox.copy();

--- a/src/kicad/text/lib-text.ts
+++ b/src/kicad/text/lib-text.ts
@@ -12,7 +12,7 @@ import { EDAText } from "./eda-text";
  * text and doesn't include fields, pin names, or pin numbers.
  *
  * Note: the methods normalize_text, rotate, mirror_horizontal, and
- * mirror_vertical are all implemented in order to match KiCAD's behavior, see
+ * mirror_vertical are all implemented in order to match KiCad's behavior, see
  * apply_symbol_transformations().
  *
  */
@@ -52,7 +52,7 @@ export class LibText extends EDAText {
     /**
      * Returns the center of the text's BBox in world coordinates.
      *
-     * This contains the positioning logic KiCAD performs in
+     * This contains the positioning logic KiCad performs in
      * SCH_PAINTER::Draw(LIB_TEXT). It made more sense for it to be here for
      * us.
      */
@@ -93,12 +93,12 @@ export class LibText extends EDAText {
      * Applies symbol transformation (rotation, position, mirror).
      *
      * Uses the rotate() and mirror_*() methods to properly orient and position
-     * symbol text, since KiCAD does not directly use a symbol's transformation
-     * to orient text. Instead, KiCAD deep copies the library symbol then calls
+     * symbol text, since KiCad does not directly use a symbol's transformation
+     * to orient text. Instead, KiCad deep copies the library symbol then calls
      * rotate() on text items multiple times based on the symbol instance's
      * rotation. This makes it non-trivial to directly set the text's location
      * and orientation, so we adopt their somewhat convoluted method. See
-     * KiCAD's sch_painter.cpp::orientSymbol.
+     * KiCad's sch_painter.cpp::orientSymbol.
      */
     apply_symbol_transformations(transforms: {
         position: Vec2;
@@ -167,7 +167,7 @@ export class LibText extends EDAText {
     /**
      * Rotate the text
      *
-     * KiCAD's rotation of LIB_TEXT objects is somewhat convoluted, but
+     * KiCad's rotation of LIB_TEXT objects is somewhat convoluted, but
      * essentially the text is moved to the center of its current bounding box,
      * rotated around the center, and then offset from the center of the
      * bounding box based on the text justification.

--- a/src/kicad/text/markup.ts
+++ b/src/kicad/text/markup.ts
@@ -5,9 +5,9 @@
 */
 
 /**
- * KiCAD text markup parser
+ * KiCad text markup parser
  *
- * KiCAD uses basic text markup to express subscript, superscript, and overbar
+ * KiCad uses basic text markup to express subscript, superscript, and overbar
  * text. For example "normal ^{superscript} _{subscript} ~{overbar}".
  */
 export class Markup {

--- a/src/kicad/text/sch-field.ts
+++ b/src/kicad/text/sch-field.ts
@@ -17,7 +17,7 @@ type Parent = {
  * Represents a symbol (or sheet) "field", such as the reference, value, or
  * other properties shown along with the symbol.
  *
- * This corresponds to and is roughly based on KiCAD's SCH_FIELD class.
+ * This corresponds to and is roughly based on KiCad's SCH_FIELD class.
  */
 export class SchField extends EDAText {
     constructor(
@@ -42,11 +42,11 @@ export class SchField extends EDAText {
         const parent_transform = this.parent?.transform ?? Matrix3.identity();
 
         // Note: this checks the parent's rotation based on its transform.
-        // KiCAD represents transforms with a simple 2x2 matrix which
+        // KiCad represents transforms with a simple 2x2 matrix which
         // can be made from a Matrix3 using:
         // kicad_matrix = [
         //      m.elements[0], m.elements[1], m.elements[3], m.elements[4]];
-        // KiCAD sets the transform of a symbol instance in
+        // KiCad sets the transform of a symbol instance in
         // SCH_SEXPR_PARSER::parseSchematicSymbol() to one of four values
         // depending on the orientation:
         //

--- a/src/kicad/text/stroke-font.ts
+++ b/src/kicad/text/stroke-font.ts
@@ -14,7 +14,7 @@ import * as newstroke from "./newstroke-glyphs";
  *
  * Stroke font are "Hershey" fonts comprised of strokes.
  *
- * This class is adapted from KiCAD's STROKE_FONT.
+ * This class is adapted from KiCad's STROKE_FONT.
  */
 export class StrokeFont extends Font {
     static readonly overbar_position_factor = 1.4;
@@ -100,7 +100,7 @@ export class StrokeFont extends Font {
             bold,
             italic,
         );
-        // KiCAD grows the bounding box a little for stroke fonts to
+        // KiCad grows the bounding box a little for stroke fonts to
         // accommodate descenders and such.
         const padding = thickness * 1.25 * 2;
         extents.x += padding;
@@ -117,7 +117,7 @@ export class StrokeFont extends Font {
     }
 
     override get_interline(glyph_height: number, line_spacing = 1): number {
-        // KiCAD doesn't include glyph thickness for interline spacing in
+        // KiCad doesn't include glyph thickness for interline spacing in
         // order to keep the spacing between bold and normal text the same.
         return glyph_height * line_spacing * StrokeFont.interline_pitch_ratio;
     }
@@ -206,7 +206,7 @@ export class StrokeFont extends Font {
         let has_bar = false;
         const bar_offset = new Vec2(0, 0);
 
-        // KiCAD shortens the overbar slightly
+        // KiCad shortens the overbar slightly
         const bar_trim = glyph_size.x * 0.1;
 
         if (style.overbar) {
@@ -220,7 +220,7 @@ export class StrokeFont extends Font {
         }
 
         // Note: KiCanvas treats underline and overbar as mutually exclusive,
-        // but technically KiCAD can show both at the same time. I wasn't able
+        // but technically KiCad can show both at the same time. I wasn't able
         // to find an actual real world case of this.
         if (has_bar) {
             if (style.italic) {
@@ -287,10 +287,10 @@ function decode_coord(c: [string, string]): [number, number] {
 /**
  * Parses a newstroke glyph
  *
- * Newstroke is distributed as a .cpp file and a old-format KiCAD library,
+ * Newstroke is distributed as a .cpp file and a old-format KiCad library,
  * this script reads a JS-ified version.
  *
- * The code here is based on KiCAD's STROKE_FONT::LoadNewStrokeFont
+ * The code here is based on KiCad's STROKE_FONT::LoadNewStrokeFont
  *
  *  Notes:
  *  - Coordinate values are coded as ASCII characters relative to "R".

--- a/src/kicanvas/elements/common/help-panel.ts
+++ b/src/kicanvas/elements/common/help-panel.ts
@@ -34,7 +34,7 @@ export class KCHelpPanel extends KCUIElement {
                     <p>
                         You're using
                         <a href="https://kicanvas.org/home">KiCanvas</a>, an
-                        interactive, browser-based viewer for KiCAD schematics
+                        interactive, browser-based viewer for KiCad schematics
                         and boards.
                     </p>
                     <p>

--- a/src/kicanvas/elements/kc-board/info-panel.ts
+++ b/src/kicanvas/elements/kc-board/info-panel.ts
@@ -48,7 +48,7 @@ export class KCBoardInfoPanelElement extends KCUIElement {
                         ${entry("Width", ds.width, "mm")}
                         ${entry("Height", ds.height, "mm")}
                         ${header("Board properties")}
-                        ${entry("KiCAD version", board.version)}
+                        ${entry("KiCad version", board.version)}
                         ${entry("Generator", board.generator)}
                         ${entry(
                             "Thickness",

--- a/src/kicanvas/elements/kc-schematic/info-panel.ts
+++ b/src/kicanvas/elements/kc-schematic/info-panel.ts
@@ -55,7 +55,7 @@ export class KCSchematicInfoPanel extends KCUIElement {
                         ${entry("Width", ds.width, "mm")}
                         ${entry("Height", ds.height, "mm")}
                         ${header("Schematic properties")}
-                        ${entry("KiCAD version", schematic.version)}
+                        ${entry("KiCad version", schematic.version)}
                         ${entry("Generator", schematic.generator)}
                         ${entry("Title", schematic.title_block?.title)}
                         ${entry("Date", schematic.title_block?.date)}

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -158,7 +158,7 @@ class KiCanvasShellElement extends KCUIElement {
                         <strong>interactive</strong>
                         ,
                         <strong>browser-based</strong>
-                        viewer for KiCAD schematics and boards. You can learn
+                        viewer for KiCad schematics and boards. You can learn
                         more from the
                         <a href="https://kicanvas.org/home" target="_blank"
                             >docs</a
@@ -177,7 +177,7 @@ class KiCanvasShellElement extends KCUIElement {
                         placeholder="Paste a GitHub link..."
                         autofocus />
                     <p>
-                        or drag & drop your KiCAD files, or<button
+                        or drag & drop your KiCad files, or<button
                             name="open_local"
                             class="link_button">
                             open from local

--- a/src/kicanvas/themes/kicad-default.ts
+++ b/src/kicanvas/themes/kicad-default.ts
@@ -9,7 +9,7 @@ import type { Theme } from "../../kicad/theme";
 
 const theme: Theme = {
     name: "kicad",
-    friendly_name: "KiCAD",
+    friendly_name: "KiCad",
     board: {
         anchor: Color.from_css("rgb(255, 38, 226)"),
         aux_items: Color.from_css("rgb(255, 255, 255)"),

--- a/src/viewers/board/painter.ts
+++ b/src/viewers/board/painter.ts
@@ -213,7 +213,7 @@ class RectPainter extends GraphicItemPainter {
 
         const color = layer.color;
 
-        // use the same order as kicad
+        // use the same order as KiCad
         // https://gitlab.com/kicad/code/develop/-/blob/master/common/eda_shape.cpp#L1616
         const points = [
             r.start,
@@ -465,7 +465,7 @@ class PadPainter extends NetNameItemPainter {
     classes = [board_items.Pad];
 
     layers_for(pad: board_items.Pad): string[] {
-        // TODO: Port KiCAD's logic over.
+        // TODO: Port KiCad's logic over.
         const layers: string[] = [];
 
         for (const layer of pad.layers) {
@@ -675,7 +675,7 @@ class PadPainter extends NetNameItemPainter {
                     break;
                 case "roundrect":
                 case "trapezoid":
-                    // KiCAD approximates rounded rectangles using four line segments
+                    // KiCad approximates rounded rectangles using four line segments
                     // with their width set to the round radius. Clever bastards.
                     // Since our polylines aren't filled, we'll add both a polygon
                     // and a polyline.
@@ -1187,7 +1187,7 @@ class DimensionPainter extends BoardItemPainter {
         this.gfx.line([ext_start, ext_end], thickness, layer.color);
 
         // Draw crossbar
-        // TODO: KiCAD checks to see if the text overlaps the crossbar and
+        // TODO: KiCad checks to see if the text overlaps the crossbar and
         // conditionally splits or hides the crossbar.
         this.gfx.line([xbar_start, xbar_end], thickness, layer.color);
 

--- a/src/viewers/schematic/painter.ts
+++ b/src/viewers/schematic/painter.ts
@@ -396,7 +396,7 @@ class PropertyPainter extends SchematicItemPainter {
         schfield.apply_effects(p.effects);
         schfield.attributes.angle = Angle.from_degrees(p.at.rotation);
 
-        // Position is tricky. KiCAD's parser calls into SCH_FIELD::SetPosition
+        // Position is tricky. KiCad's parser calls into SCH_FIELD::SetPosition
         // when parsing which sets the position relative to the parent transform
         // but KiCanvas doesn't do any of that. So we have to do that transform
         // here.

--- a/src/viewers/schematic/painters/label.ts
+++ b/src/viewers/schematic/painters/label.ts
@@ -12,10 +12,10 @@ import { LayerNames, ViewLayer } from "../layers";
 import { SchematicItemPainter } from "./base";
 
 /**
- * Implements KiCAD rendering logic for net, global, and hierarchical labels.
+ * Implements KiCad rendering logic for net, global, and hierarchical labels.
  *
  * This is similar in scope to the SymbolPin, EDAText class and its children.
- * It's designed to recreate KiCAD's behavior as closely as possible.
+ * It's designed to recreate KiCad's behavior as closely as possible.
  *
  * This logic is adapted from:
  * - SCH_LABEL_BASE

--- a/src/viewers/schematic/painters/pin.ts
+++ b/src/viewers/schematic/painters/pin.ts
@@ -18,10 +18,10 @@ import { LayerNames, ViewLayer } from "../layers";
 import { SchematicItemPainter } from "./base";
 
 /**
- * Implements KiCAD rendering logic for symbol pins.
+ * Implements KiCad rendering logic for symbol pins.
  *
  * This is similar in scope to the EDAText class and its children.  It's
- * designed to recreate KiCAD's behavior as closely as possible.
+ * designed to recreate KiCad's behavior as closely as possible.
  *
  * The logic here is based a few small bits of LIB_PIN and EDA_ITEM, with the
  * vast majority adapted from SCH_PAINTER::draw( const LIB_PIN, ...), which is
@@ -78,9 +78,9 @@ export class PinPainter extends SchematicItemPainter {
     /**
      * Applies symbol transformation (rotation, position, mirror).
      *
-     * KiCAD doesn't directly set the transformation for symbol items, instead,
+     * KiCad doesn't directly set the transformation for symbol items, instead,
      * it indirectly sets them through individual rotations and transforms.
-     * See KiCAD's sch_painter.cpp::orientSymbol.
+     * See KiCad's sch_painter.cpp::orientSymbol.
      */
     static apply_symbol_transformations(
         pin: PinInfo,
@@ -297,7 +297,7 @@ type PinOrientation = "right" | "left" | "up" | "down";
 /**
  * Converts a rotation to a pin orientation.
  *
- * KiCAD saves pin orientation as a rotation, but presents it to the UI and
+ * KiCad saves pin orientation as a rotation, but presents it to the UI and
  * does placement based on the "orientation" which is simply left, right, up,
  * or down.
  */

--- a/src/viewers/schematic/painters/symbol.ts
+++ b/src/viewers/schematic/painters/symbol.ts
@@ -155,15 +155,15 @@ export type SymbolTransform = {
 /**
  * Determines the symbol position, orientation, and mirroring
  *
- * This is based on SCH_PAINTER::orientSymbol, where KiCAD does some fun logic
+ * This is based on SCH_PAINTER::orientSymbol, where KiCad does some fun logic
  * to place a symbol instance. This tries to replicate that.
  */
 function get_symbol_transform(
     symbol: schematic_items.SchematicSymbol,
 ): SymbolTransform {
-    // Note: KiCAD uses a 2x2 transformation matrix for symbol orientation. It's
+    // Note: KiCad uses a 2x2 transformation matrix for symbol orientation. It's
     // literally the only place that uses this wacky matrix. We approximate it
-    // with carefully crafted Matrix3s. KiCAD's symbol matrix is defined as
+    // with carefully crafted Matrix3s. KiCad's symbol matrix is defined as
     //      [x1, x2]
     //      [y1, y2]
     // which cooresponds to a Matrix3 of

--- a/test/kicad/schematic.test.ts
+++ b/test/kicad/schematic.test.ts
@@ -62,7 +62,7 @@ suite("kicad.schematic.KicadSch(): schematic parsing", function () {
 
         assert.equal(sch.wires.length, 11);
 
-        // note: KiCAD saves stuff out of order, so the numbers here
+        // note: KiCad saves stuff out of order, so the numbers here
         // are goofy. They reflect the visual order of the wires/buses.
         const wire1 = sch.wires[7];
         assert_deep_partial(wire1, {

--- a/test/sch/painters/label.test.ts
+++ b/test/sch/painters/label.test.ts
@@ -31,7 +31,7 @@ suite("sch.painters.label.LabelPainter()", function () {
     const schtext = new SchText("abc");
 
     test(".get_text_offset()", function () {
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         schtext.text_size.set(12700, 12700);
         assert.equal(painter.get_text_offset(schtext), 1905);
 
@@ -40,7 +40,7 @@ suite("sch.painters.label.LabelPainter()", function () {
     });
 
     test(".get_box_expansion()", function () {
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         schtext.text_size.set(12700, 12700);
         assert.equal(painter.get_box_expansion(schtext), 4763);
 
@@ -51,7 +51,7 @@ suite("sch.painters.label.LabelPainter()", function () {
     test(".get_schematic_text_offset()", function () {
         let offset: Vec2;
 
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         schtext.text_size.set(12700, 12700);
         offset = painter.get_schematic_text_offset(null!, schtext);
         assert.equal(offset.x, 0);
@@ -83,7 +83,7 @@ suite("sch.painters.label.GlobalLabelPainter()", function () {
         let offset: Vec2;
         schtext.text_size.set(12700, 12700);
 
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         offset = painter.get_schematic_text_offset(label, schtext);
         assert.equal(offset.x, 4763);
         assert.equal(offset.y, 908);
@@ -118,7 +118,7 @@ suite("sch.painters.label.GlobalLabelPainter()", function () {
         let offset: Vec2;
         schtext.text_size.set(12700, 12700);
 
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         offset = painter.get_schematic_text_offset(label, schtext);
         assert.equal(offset.x, 14288);
         assert.equal(offset.y, 908);
@@ -145,7 +145,7 @@ suite("sch.painters.label.HierarchicalLabelPainter()", function () {
 
         let offset: Vec2;
 
-        // Reference values from KiCAD debugging
+        // Reference values from KiCad debugging
         schtext.text_size.set(12700, 12700);
         offset = painter.get_schematic_text_offset(label, schtext);
         assert.equal(offset.x, 14605);

--- a/test/sch/painters/pin.test.ts
+++ b/test/sch/painters/pin.test.ts
@@ -95,7 +95,7 @@ suite("sch.painters.pin.PinPainter", function () {
 
 suite("sch.painters.pin.PinShapeInternals", function () {
     test(".stem()", function () {
-        // Reference data from KiCAD debugging
+        // Reference data from KiCad debugging
         let stem;
 
         stem = PinShapeInternals.stem(new Vec2(1714500, 876300), "left", 25400);
@@ -129,7 +129,7 @@ suite("sch.painters.pin.PinShapeInternals", function () {
 });
 
 suite("sch.painters.pin.PinLabelInternals", function () {
-    // Reference data from KiCAD debugging
+    // Reference data from KiCad debugging
     const text_margin = 1016;
     const pin_thickness = 1524;
     const text_thickness = 1524;

--- a/test/text/eda-text.test.ts
+++ b/test/text/eda-text.test.ts
@@ -21,7 +21,7 @@ class EDATextImpl extends EDAText {
 
 suite("text.EDAText()", function () {
     test(".get_text_box() simple case", function () {
-        // Known reference values taken from KiCAD debugging.
+        // Known reference values taken from KiCad debugging.
         const text = new EDATextImpl("hello");
 
         text.text_pos = new Vec2(914400, 1066800);
@@ -46,7 +46,7 @@ suite("text.EDAText()", function () {
     });
 
     test(".get_text_box() multiline case", function () {
-        // Known reference values taken from KiCAD debugging.
+        // Known reference values taken from KiCad debugging.
 
         const text = new EDATextImpl("hello\nworld");
 

--- a/test/text/font.test.ts
+++ b/test/text/font.test.ts
@@ -20,7 +20,7 @@ suite("text.font.Font()", function () {
             new TextStyle(),
         );
 
-        // TODO: Validate sizes with KiCAD data.
+        // TODO: Validate sizes with KiCad data.
         assert.equal(words.length, 5);
         assert.equal(words[0]!.word, "hello");
         assert.equal(words[1]!.word, "world");
@@ -34,7 +34,7 @@ suite("text.font.Font()", function () {
             new TextStyle(),
         );
 
-        // Note: width reference values pulled from KiCAD debugging
+        // Note: width reference values pulled from KiCad debugging
         assert.equal(words.length, 6);
         assert.equal(words[0]!.word, "hello");
         assert.equal(Math.round(words[0]!.width), 47170);

--- a/test/text/stroke-font.test.ts
+++ b/test/text/stroke-font.test.ts
@@ -20,7 +20,7 @@ const font = StrokeFont.default();
 
 suite("text.stroke_font.StrokeFont()", function () {
     test(".get_glyph()", function () {
-        // Expected values here are pulled from KiCAD's memory after loading Newstroke.
+        // Expected values here are pulled from KiCad's memory after loading Newstroke.
 
         // space should have no strokes, but still have a bounding box.
         const space = font.get_glyph(" ");
@@ -56,7 +56,7 @@ suite("text.stroke_font.StrokeFont()", function () {
     });
 
     test(".get_interline()", function () {
-        // Expected values here are pulled from KiCAD via debugging calls to respective StrokeFont methods.
+        // Expected values here are pulled from KiCad via debugging calls to respective StrokeFont methods.
 
         assert.closeTo(font.get_interline(38100, 1), 61722, 0.5);
         assert.closeTo(font.get_interline(12700, 1), 20574, 0.5);
@@ -72,7 +72,7 @@ suite("text.stroke_font.StrokeFont()", function () {
     });
 
     test(".get_text_as_glyphs()", function () {
-        // Expected values pulled from KiCAD via debugging to StrokeFont::GetTextAsGlyphs
+        // Expected values pulled from KiCad via debugging to StrokeFont::GetTextAsGlyphs
 
         const text = "text";
         const size = new Vec2(12700, 12700);
@@ -137,7 +137,7 @@ suite("text.stroke_font.StrokeFont()", function () {
     });
 
     test(".get_text_as_glyphs() with rotated, italic", function () {
-        // Expected values pulled from KiCAD via debugging to StrokeFont::GetTextAsGlyphs
+        // Expected values pulled from KiCad via debugging to StrokeFont::GetTextAsGlyphs
 
         const text = "hello";
         const size = new Vec2(12700, 12700);
@@ -285,7 +285,7 @@ suite("text.stroke_font.StrokeFont()", function () {
         const layer = renderer.end_layer();
         const shapes = layer.shapes;
 
-        // Reference data from KiCAD debugging.
+        // Reference data from KiCad debugging.
         assert.equal(shapes.length, 5);
 
         let stroke = (shapes[0] as Polyline).points;
@@ -358,7 +358,7 @@ suite("text.stroke_font.StrokeFont()", function () {
         const layer = renderer.end_layer();
         const shapes = layer.shapes;
 
-        // Reference data from KiCAD debugging.
+        // Reference data from KiCad debugging.
         assert.equal(shapes.length, 5);
 
         let stroke = (shapes[0] as Polyline).points;

--- a/third_party/newstroke/README.txt
+++ b/third_party/newstroke/README.txt
@@ -1,28 +1,28 @@
 Newstroke Font Readme
 =====================
 
-Newstroke is a stroke (plotter) font originally designed for KiCAD.
+Newstroke is a stroke (plotter) font originally designed for KiCad.
 
 Project homepage: http://vovanium.ru/sledy/newstroke
 
 Files
 -----
-font.lib         - main glyph library in KiCAD library format
+font.lib         - main glyph library in KiCad library format
 symbol.lib       - glyph library for most math, tech and other symbols
 font_draft1.lib  - old draft glyph library with the metrics from Hersheys Simplex
-font.pro         - KiCAD project
+font.pro         - KiCad project
 charlist.txt     - unicode glyph map list
-fontconv.awk     - AWK script for 'compiling' project to c-source used by KiCAD
+fontconv.awk     - AWK script for 'compiling' project to c-source used by KiCad
 newstroke_font.h - generated c header with font
 
 Requirements
 ------------
-KiCAD (http://kicad.sourceforge.net/) - for glyph editing
+KiCad (http://kicad.sourceforge.net/) - for glyph editing
 AWK - for font generating
 
 Usage
 -----
-* Edit glyps with KiCAD EESchema library editor.
+* Edit glyphs with KiCad EESchema library editor.
 * Add Unicode positions to charlist.
 * Generate font using following command line:
 

--- a/third_party/newstroke/THIRD_PARTY_README.md
+++ b/third_party/newstroke/THIRD_PARTY_README.md
@@ -1,5 +1,5 @@
 # Newstroke font
 
-The Newstroke font is a Hershey font and is the primary font used in KiCAD. It is licensed under [Creative Commons' CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
+The Newstroke font is a Hershey font and is the primary font used in KiCad. It is licensed under [Creative Commons' CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
 
 This source distribution was retrieved from https://vovanium.ru/sledy/newstroke/en on Friday, January 20th, 2023.

--- a/third_party/newstroke/fontconv.awk
+++ b/third_party/newstroke/fontconv.awk
@@ -1,6 +1,6 @@
 #! /usr/bin/awk -f
 #
-# awk script to convert KiCAD font.
+# awk script to convert KiCad font.
 
 BEGIN {
 	print "/* Automatically converted font */"
@@ -183,7 +183,7 @@ function gaccent(b,g,anc,cx) {
 	if(!(cname(g) in fontnst)) {
 		missed += 1
 	}
-	
+
 	if(anc=="" || anc=="#") anc=""
 	ofx = offsetx(b,g,anc)
 	ofy = offsety(b,g,anc)

--- a/third_party/newstroke/newstroke_font.h
+++ b/third_party/newstroke/newstroke_font.h
@@ -4,7 +4,7 @@
  * This program source code file is part of KICAD, a free EDA CAD application.
  *
  * Copyright (C) 2010 vladimir uryvaev <vovanius@bk.ru>
- * Copyright (C) 1992-2010 Kicad Developers, see change_log.txt for contributors.
+ * Copyright (C) 1992-2010 KiCad Developers, see change_log.txt for contributors.
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
As mentioned in #163, our favourite circuit board program styles itself as KiCad.  Fixed all documentation and comments to say that.