### PR TITLE
fix: allow creating kicanvas-source element dynamically

### DIFF
--- a/src/kc-ui/focus-overlay.ts
+++ b/src/kc-ui/focus-overlay.ts
@@ -94,7 +94,6 @@ export class KCUIFocusOverlay extends KCUIElement {
 
         this.#intersection_observer = new IntersectionObserver((entries) => {
             for (const entry of entries) {
-                console.log(entry);
                 if (!entry.isIntersecting) {
                     this.classList.remove("has-focus");
                 }

--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -220,9 +220,13 @@ enum KiCanvasSourceType {
 class KiCanvasSourceElement extends CustomElement {
     constructor() {
         super();
+    }
+
+    override connectedCallback() {
         this.ariaHidden = "true";
         this.hidden = true;
         this.style.display = "none";
+        super.connectedCallback();
     }
 
     is_inline_source(): boolean {


### PR DESCRIPTION
This PR tried to fix issue #74 by moving the property initialisation into `connectedCallback`.  Now we can create `kicanvas-source` dynamically.

<img width="332" height="81" alt="image" src="https://github.com/user-attachments/assets/590ccd1f-90b1-4243-a0d2-7b927d357dfc" />
