### PR TITLE
fix: clear renderer state in SchematicSymbolPainter

### DIFF
--- a/src/viewers/schematic/painters/symbol.ts
+++ b/src/viewers/schematic/painters/symbol.ts
@@ -141,6 +141,7 @@ export class SchematicSymbolPainter extends SchematicItemPainter {
         }
 
         this.view_painter.current_symbol = undefined;
+        this.view_painter.current_symbol_transform = undefined;
     }
 }
 


### PR DESCRIPTION
It looks like we've forgotten to clear the `current_symbol_transform` in `SchematicSymbolPainter`. This resulted in the subsheet using an incorrect rendering matrix, which resulted in issue #171. This PR fix it.

https://github.com/theacodes/kicanvas/blob/6a3234e8b9dc7fe467b3cf27e169d577309a1b8e/src/viewers/schematic/painters/symbol.ts#L139-L145

This PR.

<img width="1384" height="1099" alt="image" src="https://github.com/user-attachments/assets/00afaade-8471-4cee-9f42-88f507293c78" />

Latest version (commit 6a3234e8b9dc7fe467b3cf27e169d577309a1b8e).

<img width="1384" height="1099" alt="image" src="https://github.com/user-attachments/assets/37228e1b-ba86-4af4-8857-ceaf9a6dd396" />

