### PR TITLE
feat: make it npm installable

### DIFF
--- a/docs/docs/embedding.md
+++ b/docs/docs/embedding.md
@@ -24,10 +24,24 @@ The above example shows the most basic usage of the `<kicanvas-embed>` element. 
 
 ## Installation
 
+### Pre-compiled
+
 During alpha, the best way to install KiCanvas is to [download the bundled kicanvas.js](/kicanvas/kicanvas.js), copy it into your project, and include it with a script tag:
 
 ```html
 <script type="module" src="/kicanvas.js"></script>
+```
+
+### Package installation
+
+```bash
+npm install --save https://github.com/theacodes/kicanvas
+```
+
+Ensure the package is imported somewhere like `main.ts` to enable the custom web elements.
+
+```typescript
+import "kicanvas";
 ```
 
 ## Examples

--- a/package.json
+++ b/package.json
@@ -2,7 +2,17 @@
     "name": "kicanvas",
     "version": "0.0.0",
     "description": "",
+    "main": "./src/index.ts",
+    "types": "./src/index.ts",
+    "exports": {
+        ".": "./src/index.ts"
+    },
     "type": "module",
+    "files": [
+        "src/**/*",
+        "README.md",
+        "LICENSE.md"
+    ],
     "directories": {
         "test": "tests"
     },


### PR DESCRIPTION
This will make the project installable through npm by exporting the types and main entry point. Enabling

```bash
npm install --save https://github.com/theacodes/kicanvas
```

```typescript
import "kicanvas";
```

To register the custom elements

Note, this is the first in a series of three pull-requests with the end goal of making it easier to embed in a custom typescript based web application. The pull requests will be as follows:

1) make it npm installable (this)
2) make it work with other bundles than esbuild

  All non ts import must be converted to `.ts`, example are `.glsl`, `.css`

3) make it export custom element attribute typing