### PR TITLE
fix: hide property in kicad10 schematic

### DIFF
--- a/src/kicad/schematic.ts
+++ b/src/kicad/schematic.ts
@@ -864,7 +864,9 @@ export class LibSymbol {
     };
     in_bom = false;
     on_board = false;
+    in_pos_files = true;
     exclude_from_sim = false;
+    duplicate_pin_numbers_are_jumpers = false;
     properties: Map<string, Property> = new Map();
     children: LibSymbol[] = [];
     drawings: Drawing[] = [];
@@ -896,6 +898,8 @@ export class LibSymbol {
                 ),
                 P.pair("in_bom", T.boolean),
                 P.pair("on_board", T.boolean),
+                P.pair("in_pos_files", T.boolean),
+                P.pair("duplicate_pin_numbers_are_jumpers", T.boolean),
                 P.pair("exclude_from_sim", T.boolean),
                 P.mapped_collection(
                     "properties",
@@ -1060,6 +1064,7 @@ export class Property {
     text: string;
     id: number;
     at: At;
+    hide = false;
     show_name = false;
     do_not_autoplace = false;
     #effects?: Effects;
@@ -1074,6 +1079,7 @@ export class Property {
             P.positional("name", T.string),
             P.positional("text", T.string),
             P.pair("id", T.number),
+            P.pair("hide", T.boolean),
             P.item("at", At),
             P.item("effects", Effects),
             P.atom("show_name"),
@@ -1082,6 +1088,17 @@ export class Property {
 
         this.#effects = parsed["effects"];
         delete parsed["effects"];
+
+        // KiCad 10 (ver 20260306)
+        // (property "ki_fp_filters" "R_*"
+        //    (at 0 0 0)
+        //    (hide yes))
+        // KiCad 9 and 8
+        // (property "ki_keywords" "quartz ceramic resonator oscillator"
+        //   (at 0 0 0)
+        //   (effects
+        //     (hide yes)))
+        this.hide = this.hide || (this.#effects?.hide ?? false);
 
         Object.assign(this, parsed);
     }

--- a/src/viewers/schematic/painter.ts
+++ b/src/viewers/schematic/painter.ts
@@ -389,7 +389,7 @@ class PropertyPainter extends SchematicItemPainter {
     }
 
     paint(layer: ViewLayer, p: schematic_items.Property) {
-        if (p.effects.hide || !p.text) {
+        if (p.hide || !p.text) {
             return;
         }
 

--- a/test/kicad/files/symbols_kicad10.kicad_sch
+++ b/test/kicad/files/symbols_kicad10.kicad_sch
@@ -1,0 +1,1040 @@
+(kicad_sch
+	(version 20260306)
+	(generator "eeschema")
+	(generator_version "10.0")
+	(uuid "c0326988-8693-490b-a3fb-e69d8c3ef544")
+	(paper "User" 399.999 299.999)
+	(title_block
+		(title "page title")
+		(date "2023-02-03")
+		(rev "v1")
+		(company "company")
+		(comment 1 "comment 1")
+		(comment 3 "comment 3")
+		(comment 5 "comment 5")
+		(comment 7 "comment 7")
+		(comment 9 "comment 9")
+	)
+	(lib_symbols
+		(symbol "Device:C"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C"
+				(at 0.635 -2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0.9652 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Unpolarized capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "C_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -2.032 -0.762) (xy 2.032 -0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Device:C_Polarized_US"
+			(pin_numbers
+				(hide yes)
+			)
+			(pin_names
+				(offset 0.254)
+				(hide yes)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "C"
+				(at 0.635 2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Value" "C_Polarized_US"
+				(at 0.635 -2.54 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+					(justify left)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Polarized capacitor, US symbol"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "cap capacitor"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "CP_*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "C_Polarized_US_0_1"
+				(polyline
+					(pts
+						(xy -2.032 0.762) (xy 2.032 0.762)
+					)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.778 2.286) (xy -0.762 2.286)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(polyline
+					(pts
+						(xy -1.27 1.778) (xy -1.27 2.794)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+				(arc
+					(start -2.032 -1.27)
+					(mid 0 -0.5572)
+					(end 2.032 -1.27)
+					(stroke
+						(width 0.508)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "C_Polarized_US_1_1"
+				(pin passive line
+					(at 0 3.81 270)
+					(length 2.794)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin passive line
+					(at 0 -3.81 90)
+					(length 3.302)
+					(name ""
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "Regulator_Linear:AP1117-15"
+			(pin_names
+				(offset 0.254)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "U?"
+				(at -4 -7 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "AP1117-15"
+				(at 7 -6 90)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+				(at 0 5.08 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" "http://www.diodes.com/datasheets/AP1117.pdf"
+				(at 2.54 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "1A Low Dropout regulator, positive, 1.5V fixed output, SOT-223"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "linear regulator ldo fixed positive obsolete"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_fp_filters" "SOT?223*TabPin2*"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "AP1117-15_0_0"
+				(text "lib text"
+					(at 0 0 900)
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(symbol "AP1117-15_0_1"
+				(rectangle
+					(start -5.08 -5.08)
+					(end 5.08 1.905)
+					(stroke
+						(width 0.254)
+						(type default)
+					)
+					(fill
+						(type background)
+					)
+				)
+			)
+			(symbol "AP1117-15_1_1"
+				(pin power_in line
+					(at 0 -7.62 90)
+					(length 2.54)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_out line
+					(at 7.62 0 180)
+					(length 2.54)
+					(name "VO"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "2"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+				(pin power_in line
+					(at -7.62 0 0)
+					(length 2.54)
+					(name "VI"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "3"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+		(symbol "power:GND"
+			(power global)
+			(pin_names
+				(offset 0)
+			)
+			(exclude_from_sim no)
+			(in_bom yes)
+			(on_board yes)
+			(in_pos_files yes)
+			(duplicate_pin_numbers_are_jumpers no)
+			(property "Reference" "#PWR"
+				(at 0 -6.35 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Value" "GND"
+				(at 0 -3.81 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Footprint" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Datasheet" ""
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "Description" "Power symbol creates a global label with name \"GND\" , ground"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(property "ki_keywords" "global power"
+				(at 0 0 0)
+				(show_name no)
+				(do_not_autoplace no)
+				(hide yes)
+				(effects
+					(font
+						(size 1.27 1.27)
+					)
+				)
+			)
+			(symbol "GND_0_1"
+				(polyline
+					(pts
+						(xy 0 0) (xy 0 -1.27) (xy 1.27 -1.27) (xy 0 -2.54) (xy -1.27 -1.27) (xy 0 -1.27)
+					)
+					(stroke
+						(width 0)
+						(type default)
+					)
+					(fill
+						(type none)
+					)
+				)
+			)
+			(symbol "GND_1_1"
+				(pin power_in line
+					(at 0 0 270)
+					(length 0)
+					(hide yes)
+					(name "GND"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+					(number "1"
+						(effects
+							(font
+								(size 1.27 1.27)
+							)
+						)
+					)
+				)
+			)
+			(embedded_fonts no)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 5 0 90)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5784d3e5-e4d7-444f-9621-e797ea47d2a6")
+		(property "Reference" "C?"
+			(at 5 -6.35 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "10u"
+			(at 5 -3.81 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
+			(at 8.81 -0.9652 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 5 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 5 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "5b832ff6-468c-47a1-abce-4c5a713cbfca")
+		)
+		(pin "2"
+			(uuid "ad09bea5-d46e-412d-9821-ac0de0b9cb5a")
+		)
+		(instances
+			(project "symbols_ki10"
+				(path "/c0326988-8693-490b-a3fb-e69d8c3ef544"
+					(reference "C?")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C")
+		(at 5 0 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "5f300862-b701-480a-8693-9803c387036a")
+		(property "Reference" "C1"
+			(at 8.89 -1.2701 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "10u"
+			(at 8.89 1.2699 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" "Capacitor_SMD:C_0603_1608Metric"
+			(at 5.9652 3.81 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 5 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 5 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "e7b32713-d243-40ad-98a8-3a0aff53ba0f")
+		)
+		(pin "2"
+			(uuid "baf59df8-ff4e-4424-9e10-22a14c20a2a7")
+		)
+		(instances
+			(project "symbols_ki10"
+				(path "/c0326988-8693-490b-a3fb-e69d8c3ef544"
+					(reference "C1")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "power:GND")
+		(at 0 0 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "b3886275-4fba-4a8f-b197-8451c9768307")
+		(property "Reference" "#PWR?"
+			(at 0 6.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "df3c959f-ba12-40ca-8f55-2f7e1c809287")
+		)
+		(instances
+			(project "symbols_ki10"
+				(path "/c0326988-8693-490b-a3fb-e69d8c3ef544"
+					(reference "#PWR?")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Regulator_Linear:AP1117-15")
+		(at 7 14 0)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(uuid "d8f3bdda-5eb2-4319-b3f3-d96d14a12261")
+		(property "Reference" "U?"
+			(at 3 21 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Value" "AP1117-15"
+			(at 14 20 90)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" "Package_TO_SOT_SMD:SOT-223-3_TabPin2"
+			(at 7 8.92 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" "http://www.diodes.com/datasheets/AP1117.pdf"
+			(at 9.54 20.35 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 7 14 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "75c3300b-6275-458a-8697-1ed639ea84ac")
+		)
+		(pin "2"
+			(uuid "29f72cda-5e51-472c-8069-11ddeac4b98f")
+		)
+		(pin "3"
+			(uuid "88043dea-60d9-4d18-b085-0de4ee8114b4")
+		)
+		(instances
+			(project "symbols_ki10"
+				(path "/c0326988-8693-490b-a3fb-e69d8c3ef544"
+					(reference "U?")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(symbol
+		(lib_id "Device:C_Polarized_US")
+		(at 18 0 0)
+		(mirror x)
+		(unit 1)
+		(body_style 1)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(dnp no)
+		(fields_autoplaced yes)
+		(uuid "f3b0c46b-e0f9-489f-b045-be4b5a163bb0")
+		(property "Reference" "C2"
+			(at 21.59 -0.6351 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+					(bold yes)
+					(italic yes)
+				)
+				(justify left)
+			)
+		)
+		(property "Value" "C_Polarized_US"
+			(at 21.59 1.9049 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left)
+			)
+		)
+		(property "Footprint" ""
+			(at 18 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 18 0 0)
+			(hide yes)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 18 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(pin "1"
+			(uuid "892d7c1d-84d4-4c74-bf22-802349eb11cc")
+		)
+		(pin "2"
+			(uuid "d47fc16e-e7ca-44b9-abfb-ec895a82b602")
+		)
+		(instances
+			(project "symbols_ki10"
+				(path "/c0326988-8693-490b-a3fb-e69d8c3ef544"
+					(reference "C2")
+					(unit 1)
+				)
+			)
+		)
+	)
+	(sheet_instances
+		(path "/"
+			(page "1")
+		)
+	)
+	(embedded_fonts no)
+)

--- a/test/kicad/schematic.test.ts
+++ b/test/kicad/schematic.test.ts
@@ -16,6 +16,7 @@ import drawings_sch_src from "./files/drawings.kicad_sch";
 import drawings_kicad9_sch_src from "./files/drawings_kicad9.kicad_sch";
 import symbols_sch_src from "./files/symbols.kicad_sch";
 import symbols_kicad8_sch_src from "./files/symbols_kicad8.kicad_sch";
+import symbols_kicad10_sch_src from "./files/symbols_kicad10.kicad_sch";
 
 suite("kicad.schematic.KicadSch(): schematic parsing", function () {
     test("with empty schematic file", function () {
@@ -409,6 +410,8 @@ suite("kicad.schematic.KicadSch(): schematic parsing", function () {
             name: "Datasheet",
             text: "~",
             id: 3,
+            // both hide attribute are `true`
+            hide: true,
             effects: {
                 hide: true,
             },
@@ -521,6 +524,252 @@ suite("kicad.schematic.KicadSch(): schematic parsing", function () {
         });
     });
 
+    test("with library symbols (KiCad 8)", function () {
+        const sch = new schematic.KicadSch(
+            "test.kicad8_sch",
+            symbols_kicad8_sch_src,
+        );
+
+        const symbols = Array.from(sch.symbols.values());
+        assert.equal(symbols.length, 2);
+
+        const c1 = symbols[1]!;
+        const c2 = symbols[0]!;
+
+        assert.include(c1, {
+            exclude_from_sim: true,
+        });
+
+        assert.include(c2, {
+            exclude_from_sim: false,
+        });
+
+        assert_deep_partial(c1.properties.get("Reference"), {
+            text: "C1",
+            hide: false,
+            effects: {
+                font: {
+                    size: { x: 1.27, y: 1.27 },
+                },
+            },
+        });
+
+        assert_deep_partial(c1.properties.get("Description"), {
+            text: "Unpolarized capacitor",
+            hide: true,
+            effects: {
+                font: {
+                    size: { x: 1.27, y: 1.27 },
+                },
+            },
+        });
+
+        assert_deep_partial(c2.properties.get("Reference"), {
+            text: "C2",
+            hide: false,
+            effects: {
+                font: {
+                    size: { x: 1.27, y: 1.27 },
+                },
+            },
+        });
+    });
+
+    test("with library symbols (KiCad 10)", function () {
+        const sch = new schematic.KicadSch(
+            "test.kicad_sch",
+            symbols_kicad10_sch_src,
+        );
+
+        assert.equal(sch.lib_symbols!.symbols.length, 4);
+
+        const lib_c = sch.lib_symbols!.symbols[0];
+        assert_deep_partial(lib_c, {
+            name: "Device:C",
+            pin_numbers: { hide: true },
+            pin_names: { offset: 0.254, hide: false },
+            in_bom: true,
+            on_board: true,
+            children: [
+                {
+                    name: "C_0_1",
+                    drawings: [
+                        {
+                            pts: [
+                                { x: -2.032, y: 0.762 },
+                                { x: 2.032, y: 0.762 },
+                            ],
+                            stroke: { type: "default" },
+                            fill: { type: "none" },
+                        },
+                        {
+                            pts: [
+                                { x: -2.032, y: -0.762 },
+                                { x: 2.032, y: -0.762 },
+                            ],
+                            stroke: { type: "default" },
+                            fill: { type: "none" },
+                        },
+                    ],
+                },
+                {
+                    name: "C_1_1",
+                    pins: [
+                        {
+                            type: "passive",
+                            shape: "line",
+                            at: { position: { x: 0, y: 3.81 }, rotation: 270 },
+                            length: 2.794,
+                            name: {
+                                text: "",
+                                effects: {
+                                    font: { size: { x: 1.27, y: 1.27 } },
+                                },
+                            },
+                            number: {
+                                text: "1",
+                                effects: {
+                                    font: { size: { x: 1.27, y: 1.27 } },
+                                },
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        assert_deep_partial(lib_c?.properties.get("Reference"), {
+            name: "Reference",
+            text: "C",
+            hide: false,
+            at: { position: { x: 0.635, y: 2.54 }, rotation: 0 },
+        });
+
+        assert_deep_partial(lib_c?.properties.get("Value"), {
+            name: "Value",
+            text: "C",
+            hide: false,
+        });
+
+        assert_deep_partial(lib_c?.properties.get("Footprint"), {
+            name: "Footprint",
+            text: "",
+            hide: true,
+        });
+
+        assert_deep_partial(lib_c?.properties.get("Datasheet"), {
+            name: "Datasheet",
+            text: "",
+            hide: true,
+        });
+
+        // For this one, just checking that it parsed the Arc drawing
+        // correctly, since that's the only big difference between it and the
+        // first symbol.
+        const lib_c_pol = sch.lib_symbols!.symbols[1];
+        assert_deep_partial(lib_c_pol, {
+            name: "Device:C_Polarized_US",
+            children: [
+                {
+                    name: "C_Polarized_US_0_1",
+                    drawings: [
+                        {},
+                        {},
+                        {},
+                        {
+                            start: { x: -2.032, y: -1.27 },
+                            mid: { x: 0, y: -0.5572 },
+                            end: { x: 2.032, y: -1.27 },
+                            stroke: { type: "default" },
+                            fill: { type: "none" },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        // For this one, we're checking the rectangle drawing
+        // and the different pin shapes.
+        const lib_ap1117 = sch.lib_symbols!.symbols[2];
+        assert_deep_partial(lib_ap1117, {
+            name: "Regulator_Linear:AP1117-15",
+            pin_names: {
+                hide: false,
+                offset: 0.254,
+            },
+            pin_numbers: {
+                hide: false,
+            },
+            children: [
+                {
+                    name: "AP1117-15_0_0",
+                    drawings: [
+                        {
+                            // This is a text object, and specifically we need to check that
+                            // the rotation ended up getting processed correctly.
+                            at: { position: { x: 0, y: 0 }, rotation: 90 },
+                        },
+                    ],
+                },
+                {
+                    name: "AP1117-15_0_1",
+                    drawings: [
+                        {
+                            start: { x: -5.08, y: -5.08 },
+                            end: { x: 5.08, y: 1.905 },
+                        },
+                    ],
+                },
+                {
+                    name: "AP1117-15_1_1",
+                    pins: [
+                        {
+                            type: "power_in",
+                            shape: "line",
+                            at: { position: { x: 0, y: -7.62 }, rotation: 90 },
+                            length: 2.54,
+                            name: {
+                                text: "GND",
+                                effects: {
+                                    font: { size: { x: 1.27, y: 1.27 } },
+                                },
+                            },
+                            number: {
+                                text: "1",
+                                effects: {
+                                    font: { size: { x: 1.27, y: 1.27 } },
+                                },
+                            },
+                        },
+                        { type: "power_out", name: { text: "VO" } },
+                        { type: "power_in", name: { text: "VI" } },
+                    ],
+                },
+            ],
+        });
+
+        // The last one is a power symbol
+        const lib_gnd = sch.lib_symbols!.symbols[3];
+        assert_deep_partial(lib_gnd, {
+            name: "power:GND",
+            power: true,
+            pin_names: { offset: 0 },
+            in_bom: true,
+            on_board: true,
+        });
+
+        assert_deep_partial(lib_gnd?.properties.get("Reference"), {
+            name: "Reference",
+            text: "#PWR",
+            hide: true,
+        });
+
+        assert_deep_partial(lib_gnd?.properties.get("Value"), {
+            name: "Value",
+            text: "GND",
+        });
+    });
+
     test("with symbols", function () {
         const sch = new schematic.KicadSch("test.kicad_sch", symbols_sch_src);
 
@@ -583,33 +832,6 @@ suite("kicad.schematic.KicadSch(): schematic parsing", function () {
         assert_deep_partial(symbols[4], {
             lib_id: "Device:C_Polarized_US",
             mirror: "x",
-        });
-    });
-
-    // check the KiCad8 symbol attributes
-    test("with KiCad8 exclude_from_sim attribute", function () {
-        const sch = new schematic.KicadSch(
-            "test.kicad8_sch",
-            symbols_kicad8_sch_src,
-        );
-
-        const symbols = Array.from(sch.symbols.values());
-        assert.equal(symbols.length, 2);
-
-        assert.include(symbols[0], {
-            exclude_from_sim: false,
-        });
-
-        assert.include(symbols[1], {
-            exclude_from_sim: true,
-        });
-
-        assert_deep_partial(symbols[0]?.properties.get("Reference"), {
-            text: "C2",
-        });
-
-        assert_deep_partial(symbols[1]?.properties.get("Reference"), {
-            text: "C1",
         });
     });
 });


### PR DESCRIPTION
KiCad10 moves `symbol.property.effects.hide` to `symbol.property.hide` and this PR fixes it.

```
# KiCad 10 (ver 20260306)
(property "ki_fp_filters" "R_*"
    (at 0 0 0)
    (hide yes)   <-- move to `property` node
    ... )

# KiCad 8, 9 ...
(property "ki_fp_filters" "R_*"
    (at 0 0 0)
    (effects
        (hide yes)
        ... )
    ... )
```

This PR

<img width="552" height="305" alt="image" src="https://github.com/user-attachments/assets/0a52af63-62e7-4f8e-84ec-c5e5cbfb4e31" />

Latest commit (b89e10f09b2a899ff0f2d1cc5730b02a4be3b37c)

<img width="700" height="441" alt="image" src="https://github.com/user-attachments/assets/120600a8-e95b-4d2b-a368-a6e05601a0b9" />
