### PR TITLE
fix: load sheets in subdirectory

### DIFF
--- a/src/base/dom/drag-drop.ts
+++ b/src/base/dom/drag-drop.ts
@@ -6,11 +6,11 @@
 
 import {
     DragAndDropFileSystem,
-    VirtualFileSystem,
+    type IFileSystem,
 } from "../../kicanvas/services/vfs";
 
 export class DropTarget {
-    constructor(elm: HTMLElement, callback: (fs: VirtualFileSystem) => void) {
+    constructor(elm: HTMLElement, callback: (fs: IFileSystem) => void) {
         elm.addEventListener(
             "dragenter",
             (e) => {

--- a/src/base/paths.ts
+++ b/src/base/paths.ts
@@ -21,3 +21,31 @@ export function basename(path: string | URL) {
 export function extension(path: string) {
     return path.split(".").at(-1) ?? "";
 }
+
+/**
+ * Path.join and normalize the result,
+ * It DOES NOT check relative path or absolute path.
+ * + `('', '/qwq')` -> `qwq`
+ * + `('///', '/qwq/', 'file')` -> `qwq/file`
+ */
+export function normalize_join(...parts: string[]): string {
+    return parts
+        .flatMap((p) => p.split("/"))
+        .filter((s) => s !== "")
+        .join("/");
+}
+
+/**
+ * Return relative path of `absolute` based on `parent`.
+ * + `('qwq/abc', 'qwq/abc/def/file')` -> `def/file`
+ */
+export function based_on(parent: string, absolute: string): string {
+    if (parent === absolute) {
+        return "";
+    }
+    const base = normalize_join(parent);
+    const prefix = base.length > 0 ? base + "/" : "";
+    return absolute.startsWith(prefix)
+        ? absolute.slice(prefix.length)
+        : absolute;
+}

--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -20,7 +20,7 @@ import {
     FetchFileSystem,
     LocalFileSystem,
     MergedFileSystem,
-    VirtualFileSystem,
+    type IFileSystem,
 } from "../services/vfs";
 import type { KCBoardAppElement } from "./kc-board/app";
 import type { KCSchematicAppElement } from "./kc-schematic/app";
@@ -159,7 +159,7 @@ class KiCanvasEmbedElement extends KCUIElement {
         await this.#setup_project(vfs);
     }
 
-    async #setup_project(vfs: VirtualFileSystem) {
+    async #setup_project(vfs: IFileSystem) {
         this.loaded = false;
         this.loading = true;
 

--- a/src/kicanvas/elements/kicanvas-embed.ts
+++ b/src/kicanvas/elements/kicanvas-embed.ts
@@ -164,6 +164,7 @@ class KiCanvasEmbedElement extends KCUIElement {
         this.loading = true;
 
         try {
+            await vfs.setup();
             await this.#project.load(vfs);
 
             this.loaded = true;

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -146,6 +146,7 @@ class KiCanvasShellElement extends KCUIElement {
         this.loading = true;
 
         try {
+            await vfs.setup();
             await this.project.load(vfs);
             this.project.set_active_page(this.project.first_page);
             this.loaded = true;

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -88,6 +88,9 @@ class KiCanvasShellElement extends KCUIElement {
             ...url_params.getAll("repo"),
         ];
 
+        // Only load the first URL
+        const url = urls[0];
+
         later(async () => {
             if (this.src) {
                 const vfs = new FetchFileSystem([this.src]);
@@ -95,8 +98,8 @@ class KiCanvasShellElement extends KCUIElement {
                 return;
             }
 
-            if (urls.length) {
-                const vfs = await this.load_repo(...urls);
+            if (url) {
+                const vfs = await this.load_repo(url);
                 if (!vfs) {
                     return;
                 }
@@ -134,10 +137,10 @@ class KiCanvasShellElement extends KCUIElement {
         });
     }
 
-    private async load_repo(...url: string[]): Promise<IFileSystem | null> {
+    private async load_repo(url: string): Promise<IFileSystem | null> {
         return (
-            (await GitHubFileSystem.fromURLs(...url)) ??
-            (await CodebergFileSystem.fromURLs(...url))
+            (await GitHubFileSystem.fromURLs(url)) ??
+            (await CodebergFileSystem.fromURLs(url))
         );
     }
 

--- a/src/kicanvas/elements/kicanvas-shell.ts
+++ b/src/kicanvas/elements/kicanvas-shell.ts
@@ -13,7 +13,7 @@ import { sprites_url } from "../icons/sprites";
 import { Project } from "../project";
 import { GitHubFileSystem } from "../services/github-vfs";
 import { CodebergFileSystem } from "../services/codeberg-vfs";
-import { FetchFileSystem, type VirtualFileSystem } from "../services/vfs";
+import { FetchFileSystem, type IFileSystem } from "../services/vfs";
 import { KCBoardAppElement } from "./kc-board/app";
 import { KCSchematicAppElement } from "./kc-schematic/app";
 
@@ -134,16 +134,14 @@ class KiCanvasShellElement extends KCUIElement {
         });
     }
 
-    private async load_repo(
-        ...url: string[]
-    ): Promise<VirtualFileSystem | null> {
+    private async load_repo(...url: string[]): Promise<IFileSystem | null> {
         return (
             (await GitHubFileSystem.fromURLs(...url)) ??
             (await CodebergFileSystem.fromURLs(...url))
         );
     }
 
-    private async setup_project(vfs: VirtualFileSystem) {
+    private async setup_project(vfs: IFileSystem) {
         this.loaded = false;
         this.loading = true;
 

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -54,6 +54,7 @@ export class Project extends EventTarget implements IDisposable {
 
         // 'Recursively' resolve all schematics until none remain
         let load_new = true;
+        const skipped_files: string[] = [];
         while (load_new) {
             load_new = false;
 
@@ -68,16 +69,25 @@ export class Project extends EventTarget implements IDisposable {
                     const new_file = normalize_join(base_dir, subsch.sheetfile);
 
                     const loaded = loaded_file.map((s) => s.filename);
-                    if (loaded.includes(new_file)) {
-                        // file loaded
+                    if (
+                        loaded.includes(new_file) ||
+                        skipped_files.includes(new_file)
+                    ) {
+                        // file loaded or skipped
                         continue;
                     }
 
                     load_new = true;
 
-                    // load file, it changes this.#files_by_name and causes calling
-                    // this.schematics() will return a new result.
-                    await this.#load_file(new_file);
+                    if (await this.#fs.has(new_file)) {
+                        // load file, it changes this.#files_by_name and causes calling
+                        // this.schematics() will return a new result.
+                        await this.#load_file(new_file);
+                    } else {
+                        // skip non-existent files to allow loading an incomplete schematics
+                        skipped_files.push(new_file);
+                        log.warn(`file "${new_file}" is not existed, skip it.`);
+                    }
                 }
             }
         }

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -15,12 +15,12 @@ import type {
     SchematicSheet,
     SchematicSheetInstance,
 } from "../kicad/schematic";
-import type { VirtualFileSystem } from "./services/vfs";
+import type { IFileSystem } from "./services/vfs";
 
 const log = new Logger("kicanvas:project");
 
 export class Project extends EventTarget implements IDisposable {
-    #fs: VirtualFileSystem;
+    #fs: IFileSystem;
     #files_by_name: Map<string, KicadPCB | KicadSch | null> = new Map();
     #pages_by_path: Map<string, ProjectPage> = new Map();
     #root_schematic_page?: ProjectPage;
@@ -33,7 +33,7 @@ export class Project extends EventTarget implements IDisposable {
         this.#pages_by_path.clear();
     }
 
-    public async load(fs: VirtualFileSystem) {
+    public async load(fs: IFileSystem) {
         log.info(`Loading project from ${fs.constructor.name}`);
 
         this.settings = new ProjectSettings();

--- a/src/kicanvas/project.ts
+++ b/src/kicanvas/project.ts
@@ -9,6 +9,7 @@ import { Barrier } from "../base/async";
 import { type IDisposable } from "../base/disposable";
 import { first, length, map } from "../base/iterator";
 import { Logger } from "../base/log";
+import { dirname, normalize_join } from "../base/paths";
 import { is_string, type Constructor } from "../base/types";
 import { KicadPCB, KicadSch, ProjectSettings } from "../kicad";
 import type {
@@ -42,30 +43,43 @@ export class Project extends EventTarget implements IDisposable {
 
         this.#fs = fs;
 
-        let promises = [];
+        const proj_promises = [];
 
+        // load project file
         for (const filename of this.#fs.list()) {
-            promises.push(this.#load_file(filename));
+            proj_promises.push(this.#load_file(filename));
         }
 
-        await Promise.all(promises);
+        await Promise.all(proj_promises);
 
-        while (promises.length) {
-            // 'Recursively' resolve all schematics until none remain
-            promises = [];
-            for (const schematic of this.schematics()) {
-                for (const sheet of schematic.sheets) {
-                    const sheet_sch = this.#files_by_name.get(
-                        sheet.sheetfile ?? "",
-                    ) as KicadSch;
+        // 'Recursively' resolve all schematics until none remain
+        let load_new = true;
+        while (load_new) {
+            load_new = false;
 
-                    if (!sheet_sch && sheet.sheetfile) {
-                        // Missing schematic, attempt to fetch
-                        promises.push(this.#load_file(sheet.sheetfile));
+            const loaded_file = Array.from(this.schematics());
+            for (const sch of loaded_file) {
+                const base_dir = dirname(sch.filename);
+                for (const subsch of sch.sheets) {
+                    if (!subsch.sheetfile) {
+                        continue;
                     }
+
+                    const new_file = normalize_join(base_dir, subsch.sheetfile);
+
+                    const loaded = loaded_file.map((s) => s.filename);
+                    if (loaded.includes(new_file)) {
+                        // file loaded
+                        continue;
+                    }
+
+                    load_new = true;
+
+                    // load file, it changes this.#files_by_name and causes calling
+                    // this.schematics() will return a new result.
+                    await this.#load_file(new_file);
                 }
             }
-            await Promise.all(promises);
         }
 
         this.#determine_schematic_hierarchy();
@@ -251,6 +265,10 @@ export class Project extends EventTarget implements IDisposable {
 
         // Finally, if no root schematic was found, just use the first one we saw.
         this.#root_schematic_page = first(this.#pages_by_path.values());
+
+        if (!this.#root_schematic_page) {
+            log.error("No vaild root schematic was found.");
+        }
     }
 
     public *files() {

--- a/src/kicanvas/services/codeberg-vfs.ts
+++ b/src/kicanvas/services/codeberg-vfs.ts
@@ -16,43 +16,41 @@ export class CodebergFileSystem implements IFileSystem {
     constructor(private files_to_urls: Map<string, URL>) {}
 
     public static async fromURLs(
-        ...urls: (string | URL)[]
+        url: string | URL,
     ): Promise<CodebergFileSystem | null> {
         const files_to_urls = new Map<string, URL>();
 
-        for (const url of urls) {
-            const info = Codeberg.parse_url(url);
-            if (!info) {
+        const info = Codeberg.parse_url(url);
+        if (!info) {
+            return null;
+        }
+
+        // API:
+        // https://codeberg.org/api/swagger#/repository/repoGetContents
+        const api_url = `repos/${info.owner}/${info.repo}/contents/${info.path}`;
+
+        let files = await Codeberg.request_json<
+            RepoContentResponse | RepoContentResponse[]
+        >(api_url);
+
+        if (!Array.isArray(files)) {
+            files = [files];
+        }
+
+        for (const file of files) {
+            if (!file.name || !file.git_url || file.type !== "file") {
                 continue;
             }
 
-            // API:
-            // https://codeberg.org/api/swagger#/repository/repoGetContents
-            const api_url = `repos/${info.owner}/${info.repo}/contents/${info.path}`;
-
-            let files = await Codeberg.request_json<
-                RepoContentResponse | RepoContentResponse[]
-            >(api_url);
-
-            if (!Array.isArray(files)) {
-                files = [files];
+            if (
+                !CodebergFileSystem.kicad_extensions.includes(
+                    extension(file.name),
+                )
+            ) {
+                continue;
             }
 
-            for (const file of files) {
-                if (!file.name || !file.git_url || file.type !== "file") {
-                    continue;
-                }
-
-                if (
-                    !CodebergFileSystem.kicad_extensions.includes(
-                        extension(file.name),
-                    )
-                ) {
-                    continue;
-                }
-
-                files_to_urls.set(file.name, new URL(file.git_url));
-            }
+            files_to_urls.set(file.name, new URL(file.git_url));
         }
 
         if (files_to_urls.size == 0) {

--- a/src/kicanvas/services/codeberg-vfs.ts
+++ b/src/kicanvas/services/codeberg-vfs.ts
@@ -7,14 +7,12 @@ import { base64_decode } from "../../base/base64";
 import { initiate_download } from "../../base/dom/download";
 import { extension } from "../../base/paths";
 import { Codeberg, GetBlobResponse, RepoContentResponse } from "./codeberg";
-import { VirtualFileSystem } from "./vfs";
+import { type IFileSystem } from "./vfs";
 
-export class CodebergFileSystem extends VirtualFileSystem {
+export class CodebergFileSystem implements IFileSystem {
     static readonly kicad_extensions = ["kicad_pcb", "kicad_pro", "kicad_sch"];
 
-    constructor(private files_to_urls: Map<string, URL>) {
-        super();
-    }
+    constructor(private files_to_urls: Map<string, URL>) {}
 
     public static async fromURLs(
         ...urls: (string | URL)[]
@@ -64,11 +62,11 @@ export class CodebergFileSystem extends VirtualFileSystem {
         return new CodebergFileSystem(files_to_urls);
     }
 
-    override *list(): Generator<string> {
+    *list(): Generator<string> {
         yield* this.files_to_urls.keys();
     }
 
-    override async get(name: string): Promise<File> {
+    async get(name: string) {
         const url = this.files_to_urls.get(name);
         if (!url) {
             throw new Error(`File ${name} not found.`);
@@ -87,11 +85,11 @@ export class CodebergFileSystem extends VirtualFileSystem {
         return file;
     }
 
-    override has(name: string): Promise<boolean> {
+    async has(name: string) {
         return Promise.resolve(this.files_to_urls.has(name));
     }
 
-    override async download(name: string): Promise<void> {
+    async download(name: string) {
         initiate_download(await this.get(name));
     }
 }

--- a/src/kicanvas/services/codeberg-vfs.ts
+++ b/src/kicanvas/services/codeberg-vfs.ts
@@ -12,6 +12,7 @@ import { type IFileSystem } from "./vfs";
 export class CodebergFileSystem implements IFileSystem {
     static readonly kicad_extensions = ["kicad_pcb", "kicad_pro", "kicad_sch"];
 
+    async setup() {}
     constructor(private files_to_urls: Map<string, URL>) {}
 
     public static async fromURLs(

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -35,12 +35,11 @@ export class GitHubFileSystem extends FileSystemBase {
         if (single_file) {
             // Handles URLs like this:
             // https://github.com/wntrblm/Helium/blob/main/hardware/board/board.kicad_sch
+            // In single-file mode, just store file basename
             const guc_url = gh_user_content.convert_url(url);
             const name = basename(guc_url);
             this.download_urls.set(name, guc_url);
         }
-
-        console.log(url, gh_repo);
     }
 
     override async load_file(path: string): Promise<File> {

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -21,64 +21,60 @@ export class GitHubFileSystem implements IFileSystem {
 
     async setup() {}
     public static async fromURLs(
-        ...urls: (string | URL)[]
+        url: string | URL,
     ): Promise<GitHubFileSystem | null> {
         // Handles URLs like this:
         // https://github.com/wntrblm/Helium/blob/main/hardware/board/board.kicad_sch
 
         const files_to_urls = new Map();
 
-        for (const url of urls) {
-            const info = GitHub.parse_url(url);
+        const info = GitHub.parse_url(url);
 
-            if (!info || !info.owner || !info.repo) {
-                continue;
-            }
+        if (!info || !info.owner || !info.repo) {
+            return null;
+        }
 
-            // Link to the root of a repo, treat it as tree using HEAD
-            if (info.type == "root") {
-                info.ref = "HEAD";
+        // Link to the root of a repo, treat it as tree using HEAD
+        if (info.type == "root") {
+            info.ref = "HEAD";
+            info.type = "tree";
+        }
+
+        // Link to a single file.
+        if (info.type == "blob") {
+            if (["kicad_sch", "kicad_pcb"].includes(extension(info.path!))) {
+                const guc_url = gh_user_content.convert_url(url);
+                const name = basename(guc_url);
+                files_to_urls.set(name, guc_url);
+            } else {
+                // Link to non-kicad file, try using the containing directory.
                 info.type = "tree";
+                info.path = dirname(info.path!);
             }
+        }
 
-            // Link to a single file.
-            if (info.type == "blob") {
+        // Link to a directory.
+        if (info.type == "tree") {
+            // Get a list of files in the directory.
+            const gh_file_list = (await gh.repos_contents(
+                info.owner,
+                info.repo,
+                info.path ?? "",
+                info.ref,
+            )) as Record<string, string>[];
+
+            for (const gh_file of gh_file_list) {
+                const name = gh_file["name"];
+                const download_url = gh_file["download_url"];
                 if (
-                    ["kicad_sch", "kicad_pcb"].includes(extension(info.path!))
+                    !name ||
+                    !download_url ||
+                    !kicad_extensions.includes(extension(name))
                 ) {
-                    const guc_url = gh_user_content.convert_url(url);
-                    const name = basename(guc_url);
-                    files_to_urls.set(name, guc_url);
-                } else {
-                    // Link to non-kicad file, try using the containing directory.
-                    info.type = "tree";
-                    info.path = dirname(info.path!);
+                    continue;
                 }
-            }
 
-            // Link to a directory.
-            if (info.type == "tree") {
-                // Get a list of files in the directory.
-                const gh_file_list = (await gh.repos_contents(
-                    info.owner,
-                    info.repo,
-                    info.path ?? "",
-                    info.ref,
-                )) as Record<string, string>[];
-
-                for (const gh_file of gh_file_list) {
-                    const name = gh_file["name"];
-                    const download_url = gh_file["download_url"];
-                    if (
-                        !name ||
-                        !download_url ||
-                        !kicad_extensions.includes(extension(name))
-                    ) {
-                        continue;
-                    }
-
-                    files_to_urls.set(name, download_url);
-                }
+                files_to_urls.set(name, download_url);
             }
         }
 

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -4,33 +4,101 @@
     Full text available at: https://opensource.org/licenses/MIT
 */
 
-import { initiate_download } from "../../base/dom/download";
-import { basename, dirname, extension } from "../../base/paths";
-import { GitHub, GitHubUserContent } from "./github";
-import { type IFileSystem } from "./vfs";
+import {
+    basename,
+    dirname,
+    extension,
+    normalize_join,
+    based_on,
+} from "../../base/paths";
+import { GitHub, GitHubUserContent, type GitHubURLInfo } from "./github";
+import { FileSystemBase, type FileEntry } from "./vfs";
 
-const kicad_extensions = ["kicad_pcb", "kicad_pro", "kicad_sch"];
 const gh_user_content = new GitHubUserContent();
 const gh = new GitHub();
 
 /**
  * Virtual file system for GitHub.
  */
-export class GitHubFileSystem implements IFileSystem {
-    constructor(private files_to_urls: Map<string, URL>) {}
+export class GitHubFileSystem extends FileSystemBase {
+    private download_urls: Map<string, URL>;
 
-    async setup() {}
+    constructor(
+        url: string | URL,
+        private gh_repo: GitHubURLInfo,
+        private single_file = false,
+    ) {
+        super();
+        this.download_urls = new Map<string, URL>();
+
+        // try using `raw.github` directly for single file
+        if (single_file) {
+            // Handles URLs like this:
+            // https://github.com/wntrblm/Helium/blob/main/hardware/board/board.kicad_sch
+            const guc_url = gh_user_content.convert_url(url);
+            const name = basename(guc_url);
+            this.download_urls.set(name, guc_url);
+        }
+
+        console.log(url, gh_repo);
+    }
+
+    override async load_file(path: string): Promise<File> {
+        const download_url = this.download_urls.get(path);
+        if (!download_url) {
+            throw new Error(`File ${path} not found!`);
+        }
+
+        return await gh_user_content.get(download_url);
+    }
+
+    override async enumrate(cur_dir: string): Promise<FileEntry[]> {
+        if (this.single_file) {
+            // single file, return all files directly
+            return Array.from(this.download_urls.keys()).map((v) => ({
+                type: "file",
+                path: v,
+            }));
+        }
+
+        const base_dir = this.gh_repo.path ?? "";
+        const full_path = normalize_join(base_dir, cur_dir);
+
+        const contents = await gh.repos_contents(
+            this.gh_repo.owner,
+            this.gh_repo.repo,
+            full_path,
+            this.gh_repo.ref,
+        );
+
+        const result: FileEntry[] = [];
+        for (const it of contents) {
+            if (it.type === "file" && GitHubFileSystem.is_kicad_file(it.name)) {
+                const file_path = based_on(base_dir, it.path);
+
+                this.download_urls.set(file_path, new URL(it.download_url));
+
+                result.push({
+                    type: "file",
+                    path: file_path,
+                });
+            } else if (it.type === "dir") {
+                result.push({
+                    type: "directory",
+                    path: based_on(base_dir, it.path),
+                });
+            }
+        }
+
+        return result;
+    }
+
     public static async fromURLs(
         url: string | URL,
     ): Promise<GitHubFileSystem | null> {
-        // Handles URLs like this:
-        // https://github.com/wntrblm/Helium/blob/main/hardware/board/board.kicad_sch
-
-        const files_to_urls = new Map();
-
         const info = GitHub.parse_url(url);
 
-        if (!info || !info.owner || !info.repo) {
+        if (!info) {
             return null;
         }
 
@@ -40,12 +108,11 @@ export class GitHubFileSystem implements IFileSystem {
             info.type = "tree";
         }
 
-        // Link to a single file.
-        if (info.type == "blob") {
+        // If it's one file just load one file.
+        let single_file = false;
+        if (info.type === "blob") {
             if (["kicad_sch", "kicad_pcb"].includes(extension(info.path!))) {
-                const guc_url = gh_user_content.convert_url(url);
-                const name = basename(guc_url);
-                files_to_urls.set(name, guc_url);
+                single_file = true;
             } else {
                 // Link to non-kicad file, try using the containing directory.
                 info.type = "tree";
@@ -53,62 +120,6 @@ export class GitHubFileSystem implements IFileSystem {
             }
         }
 
-        // Link to a directory.
-        if (info.type == "tree") {
-            // Get a list of files in the directory.
-            const gh_file_list = (await gh.repos_contents(
-                info.owner,
-                info.repo,
-                info.path ?? "",
-                info.ref,
-            )) as Record<string, string>[];
-
-            for (const gh_file of gh_file_list) {
-                const name = gh_file["name"];
-                const download_url = gh_file["download_url"];
-                if (
-                    !name ||
-                    !download_url ||
-                    !kicad_extensions.includes(extension(name))
-                ) {
-                    continue;
-                }
-
-                files_to_urls.set(name, download_url);
-            }
-        }
-
-        if (files_to_urls.size == 0) {
-            // no valid URL and files, return null.
-            return null;
-        }
-
-        return new GitHubFileSystem(files_to_urls);
-    }
-
-    *list() {
-        yield* this.files_to_urls.keys();
-    }
-
-    async get(name: string) {
-        const url = this.files_to_urls.get(name);
-
-        if (!url) {
-            throw new Error(`File ${name} not found!`);
-        }
-
-        return gh_user_content.get(url);
-    }
-
-    async has(name: string) {
-        return Promise.resolve(this.files_to_urls.has(name));
-    }
-
-    async download(name: string) {
-        // Note: we can't just use the GitHub URL to download since the anchor
-        // tag method used by initiate_download() only works for same-origin
-        // or data: urls, so this actually fetch()s the file and then initiates
-        // the download.
-        initiate_download(await this.get(name));
+        return new GitHubFileSystem(url, info, single_file);
     }
 }

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -19,6 +19,7 @@ const gh = new GitHub();
 export class GitHubFileSystem implements IFileSystem {
     constructor(private files_to_urls: Map<string, URL>) {}
 
+    async setup() {}
     public static async fromURLs(
         ...urls: (string | URL)[]
     ): Promise<GitHubFileSystem | null> {

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -51,7 +51,7 @@ export class GitHubFileSystem extends FileSystemBase {
         return await gh_user_content.get(download_url);
     }
 
-    override async enumrate(cur_dir: string): Promise<FileEntry[]> {
+    override async enumerate(cur_dir: string): Promise<FileEntry[]> {
         if (this.single_file) {
             // single file, return all files directly
             return Array.from(this.download_urls.keys()).map((v) => ({

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -7,7 +7,7 @@
 import { initiate_download } from "../../base/dom/download";
 import { basename, dirname, extension } from "../../base/paths";
 import { GitHub, GitHubUserContent } from "./github";
-import { VirtualFileSystem } from "./vfs";
+import { type IFileSystem } from "./vfs";
 
 const kicad_extensions = ["kicad_pcb", "kicad_pro", "kicad_sch"];
 const gh_user_content = new GitHubUserContent();
@@ -16,10 +16,8 @@ const gh = new GitHub();
 /**
  * Virtual file system for GitHub.
  */
-export class GitHubFileSystem extends VirtualFileSystem {
-    constructor(private files_to_urls: Map<string, URL>) {
-        super();
-    }
+export class GitHubFileSystem implements IFileSystem {
+    constructor(private files_to_urls: Map<string, URL>) {}
 
     public static async fromURLs(
         ...urls: (string | URL)[]
@@ -91,11 +89,11 @@ export class GitHubFileSystem extends VirtualFileSystem {
         return new GitHubFileSystem(files_to_urls);
     }
 
-    public override *list() {
+    *list() {
         yield* this.files_to_urls.keys();
     }
 
-    public override get(name: string): Promise<File> {
+    async get(name: string) {
         const url = this.files_to_urls.get(name);
 
         if (!url) {
@@ -105,11 +103,11 @@ export class GitHubFileSystem extends VirtualFileSystem {
         return gh_user_content.get(url);
     }
 
-    public override has(name: string) {
+    async has(name: string) {
         return Promise.resolve(this.files_to_urls.has(name));
     }
 
-    public override async download(name: string) {
+    async download(name: string) {
         // Note: we can't just use the GitHub URL to download since the anchor
         // tag method used by initiate_download() only works for same-origin
         // or data: urls, so this actually fetch()s the file and then initiates

--- a/src/kicanvas/services/github.ts
+++ b/src/kicanvas/services/github.ts
@@ -7,6 +7,26 @@
 import { basename } from "../../base/paths";
 import { request_error_handler } from "./api-error";
 
+export class GitHubURLInfo {
+    owner: string;
+    repo: string;
+    type: string;
+    ref?: string;
+    path?: string;
+}
+
+export class GithubContentResponse {
+    download_url: string;
+    git_url: string;
+    html_url: string;
+    name: string;
+    path: string;
+    sha: string;
+    size: number;
+    type: string;
+    url: string;
+}
+
 export class GitHub {
     static readonly host_name = "github.com";
     static readonly html_base_url = "https://github.com";
@@ -28,7 +48,7 @@ export class GitHub {
     /**
      * Parse an html (user-facing) URL
      */
-    static parse_url(url: string | URL) {
+    static parse_url(url: string | URL): GitHubURLInfo | null {
         url = new URL(url, GitHub.html_base_url);
         if (url.hostname != GitHub.host_name) {
             return null;
@@ -41,6 +61,9 @@ export class GitHub {
         }
 
         const [, owner, repo, ...parts] = path_parts;
+        if (!owner || !repo) {
+            return null;
+        }
 
         let type;
         let ref;
@@ -54,6 +77,10 @@ export class GitHub {
             }
         } else {
             type = "root";
+        }
+
+        if (!type) {
+            return null;
         }
 
         return {
@@ -111,9 +138,11 @@ export class GitHub {
         path: string,
         ref?: string,
     ) {
-        return await this.request(`repos/${owner}/${repo}/contents/${path}`, {
+        // https://docs.github.com/en/rest/repos/contents
+        // <api_base>/repos/{owner}/{repo}/contents/{path}
+        return (await this.request(`repos/${owner}/${repo}/contents/${path}`, {
             ref: ref ?? "",
-        });
+        })) as GithubContentResponse[];
     }
 }
 

--- a/src/kicanvas/services/github.ts
+++ b/src/kicanvas/services/github.ts
@@ -5,6 +5,7 @@
 */
 
 import { basename } from "../../base/paths";
+import { is_array } from "../../base/types";
 import { request_error_handler } from "./api-error";
 
 export class GitHubURLInfo {
@@ -140,9 +141,16 @@ export class GitHub {
     ) {
         // https://docs.github.com/en/rest/repos/contents
         // <api_base>/repos/{owner}/{repo}/contents/{path}
-        return (await this.request(`repos/${owner}/${repo}/contents/${path}`, {
-            ref: ref ?? "",
-        })) as GithubContentResponse[];
+        const result = await this.request(
+            `repos/${owner}/${repo}/contents/${path}`,
+            {
+                ref: ref ?? "",
+            },
+        );
+
+        return is_array(result)
+            ? (result as GithubContentResponse[])
+            : [result as GithubContentResponse];
     }
 }
 

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -67,7 +67,7 @@ export abstract class FileSystemBase implements IFileSystem {
     // root.kicad_pcb -> { name: "root.kicad_pcb", type: "file" }
     // subdir -> { name: "subdir", type: "directory" }
     // subdir/qwq1.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
-    // subdir/qwq2.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
+    // subdir/qwq2.kicad_sch -> { name: "subdir/qwq2.kicad_sch", type: "file" }
     private entries: Map<string, FileEntryCache>;
 
     constructor(entries: Map<string, FileEntry> = new Map()) {
@@ -96,12 +96,8 @@ export abstract class FileSystemBase implements IFileSystem {
     }
 
     async has(name: string) {
-        if (this.entries.has(name)) {
-            return true;
-        }
-
         const dir = dirname(name);
-        if (!this.entries.has(dir)) {
+        if (!this.entries.has(dir) && !this.entries.has(name)) {
             return false;
         }
 

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -5,7 +5,7 @@
 */
 
 import { initiate_download } from "../../base/dom/download";
-import { basename } from "../../base/paths";
+import { basename, dirname, extension } from "../../base/paths";
 
 /**
  * Virtual file system interface.
@@ -15,25 +15,136 @@ import { basename } from "../../base/paths";
  * for interacting and loading files.
  */
 export interface IFileSystem {
-    /**
-     * List all files in the file system
-     */
+    /** List all files */
     list(): Generator<string>;
 
-    /**
-     * Get a file from the file system
-     */
-    get(name: string): Promise<File>;
+    /** Initialize it */
+    setup(): Promise<void>;
 
-    /**
-     * Return true if current file list has `name`
-     */
-    has(name: string): Promise<boolean>;
+    /** Get a file */
+    get(path: string): Promise<File>;
 
-    /**
-     * Download a file from the file system. This is used by the "Download" button
-     */
+    /** Return true if current file list has `path` */
+    has(path: string): Promise<boolean>;
+
+    /** Download a file from the file system */
     download(name: string): Promise<void>;
+}
+
+/**
+ * File entry, directory or file
+ */
+export interface FileEntry {
+    name: string;
+    type: "file" | "directory";
+}
+
+/**
+ * File system base
+ */
+export abstract class FileSystemBase implements IFileSystem {
+    // path -> entry
+    // e.g.
+    //   + root.kicad_pcb
+    //   + subdir/
+    //     + qwq1.kicad_sch
+    //     + qwq2.kicad_sch
+    // stored as
+    // root.kicad_pcb -> { name: "root.kicad_pcb", type: "file" }
+    // subdir -> { name: "subdir", type: "directory" }   <-- optional
+    // subdir/qwq1.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
+    // subdir/qwq2.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
+    private entries: Map<string, FileEntry>;
+
+    constructor(entries: Map<string, FileEntry> = new Map()) {
+        this.entries = entries;
+    }
+
+    *list() {
+        for (const [path, entry] of this.entries) {
+            if (entry.type === "file") {
+                yield path;
+            }
+        }
+    }
+
+    async setup() {
+        // load all entries on root directory
+        await this.walk("");
+    }
+
+    async get(name: string) {
+        if (!(await this.has(name))) {
+            throw new Error(`File ${name} not found`);
+        }
+
+        return await this.load_file(name);
+    }
+
+    async has(name: string) {
+        // load entries on current directory
+        const dir = dirname(name);
+        await this.walk(dir);
+
+        // check if the file exists and is a file
+        const obj = this.entries.get(name);
+        return !!obj && obj.type === "file";
+    }
+
+    async download(name: string) {
+        initiate_download(await this.get(name));
+    }
+
+    /**
+     * Return true if a file has extension name `.kicad_pcb`, `.kicad_prj` or `.kicad_sch`
+     */
+    protected static is_kicad_file(name: string): boolean {
+        const exts = ["kicad_pcb", "kicad_pro", "kicad_sch"];
+
+        return exts.includes(extension(name));
+    }
+
+    /**
+     * Walk through directories to find file entry,
+     * and update entries cache.
+     */
+    private async walk(dir: string): Promise<void> {
+        const queue: string[] = [dir];
+
+        while (queue.length > 0) {
+            const dir = queue.shift()!;
+
+            if (this.entries.has(dir)) {
+                continue;
+            }
+
+            const entries = await this.enumrate(dir);
+            this.entries.set(dir, { name: dir, type: "directory" });
+
+            for (const entry of entries) {
+                if (entry.name.startsWith(dir) && entry.type === "directory") {
+                    // walking into subdirectory
+                    queue.push(entry.name);
+                }
+
+                // cache the result
+                const full_path =
+                    dir.length === 0 ? entry.name : `${dir}/${entry.name}`;
+                const abs_entry = { name: full_path, type: entry.type };
+                this.entries.set(full_path, abs_entry);
+            }
+        }
+    }
+
+    /**
+     * Load file from implementation-specific source
+     */
+    protected abstract load_file(path: string): Promise<File>;
+
+    /**
+     * Enumerate files at `base_dir`. (default: empty)
+     */
+    protected abstract enumrate(base_dir: string): Promise<FileEntry[]>;
 }
 
 /**
@@ -49,6 +160,12 @@ export class MergedFileSystem implements IFileSystem {
     *list() {
         for (const fs of this.fs_list) {
             yield* fs.list();
+        }
+    }
+
+    async setup() {
+        for (const fs of this.fs_list) {
+            await fs.setup();
         }
     }
 
@@ -84,9 +201,43 @@ export class MergedFileSystem implements IFileSystem {
 }
 
 /**
+ * Local file system base class, with a file list provided by the constructor.
+ */
+export class LocalFileSystemBase extends FileSystemBase {
+    constructor(private file_list: Map<string, File>) {
+        super(LocalFileSystemBase.into_entries(file_list));
+    }
+
+    async load_file(path: string): Promise<File> {
+        const file = this.file_list.get(path);
+
+        if (!file) {
+            throw new Error(`File ${path} not found!`);
+        }
+
+        return file;
+    }
+
+    async enumrate(base_dir: string): Promise<FileEntry[]> {
+        // All files are already provided by the constructor.
+        return [];
+    }
+
+    private static into_entries(files: Map<string, File>) {
+        const result = new Map<string, FileEntry>();
+
+        for (const path of files.keys()) {
+            result.set(path, { name: path, type: "file" });
+        }
+
+        return result;
+    }
+}
+
+/**
  * Virtual file system for URLs via Fetch
  */
-export class FetchFileSystem implements IFileSystem {
+export class FetchFileSystem extends FileSystemBase {
     private urls: Map<string, URL> = new Map();
     private resolver!: (name: string) => URL;
 
@@ -114,6 +265,8 @@ export class FetchFileSystem implements IFileSystem {
         urls: (string | URL)[],
         resolve_file: ((name: string) => URL) | null = null,
     ) {
+        super();
+
         this.resolver = resolve_file ?? this.#default_resolver;
 
         for (const item of urls) {
@@ -121,19 +274,11 @@ export class FetchFileSystem implements IFileSystem {
         }
     }
 
-    *list() {
-        yield* this.urls.keys();
-    }
-
-    async has(name: string) {
-        return Promise.resolve(this.urls.has(name));
-    }
-
-    async get(name: string): Promise<File> {
-        const url = this.#resolve(name);
+    async load_file(path: string): Promise<File> {
+        const url = this.#resolve(path);
 
         if (!url) {
-            throw new Error(`File ${name} not found!`);
+            throw new Error(`File ${path} not found!`);
         }
 
         const request = new Request(url, { method: "GET" });
@@ -147,22 +292,23 @@ export class FetchFileSystem implements IFileSystem {
 
         const blob = await response.blob();
 
-        return new File([blob], name);
+        return new File([blob], path);
     }
 
-    async download(name: string) {
-        initiate_download(await this.get(name));
+    async enumrate(base_dir: string): Promise<FileEntry[]> {
+        return Array.from(this.urls.keys()).map((name) => ({
+            name,
+            type: "file",
+        }));
     }
 }
 
 /**
  * Virtual file system for HTML drag and drop (DataTransfer)
  */
-export class DragAndDropFileSystem implements IFileSystem {
-    constructor(private items: FileSystemFileEntry[]) {}
-
+export class DragAndDropFileSystem extends LocalFileSystemBase {
     static async fromDataTransfer(dt: DataTransfer) {
-        let items: FileSystemEntry[] = [];
+        const items: FileSystemEntry[] = [];
 
         // Pluck items out as webkit entries (either FileSystemFileEntry or
         // FileSystemDirectoryEntry)
@@ -173,95 +319,93 @@ export class DragAndDropFileSystem implements IFileSystem {
             }
         }
 
-        // If it's just one directory then open it and set all of our items
-        // to its contents.
-        if (items.length == 1 && items[0]?.isDirectory) {
-            const reader = (
-                items[0] as FileSystemDirectoryEntry
-            ).createReader();
+        // walk through directories and collect all file entries
+        const files = await DragAndDropFileSystem.walk(items);
 
-            items = [];
-
-            await new Promise((resolve, reject) => {
-                reader.readEntries((entries) => {
-                    for (const entry of entries) {
-                        if (!entry.isFile) {
-                            continue;
-                        }
-                        items.push(entry);
-                    }
-                    resolve(true);
-                }, reject);
-            });
-        }
-
-        return new DragAndDropFileSystem(items as FileSystemFileEntry[]);
-    }
-
-    *list() {
-        for (const entry of this.items) {
-            yield entry.name;
-        }
-    }
-
-    async has(name: string): Promise<boolean> {
-        for (const entry of this.items) {
-            if (entry.name == name) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    async get(name: string): Promise<File> {
-        let file_entry: FileSystemFileEntry | null = null;
-        for (const entry of this.items) {
-            if (entry.name == name) {
-                file_entry = entry;
-                break;
+        // load kicad files
+        const file_map = new Map<string, File>();
+        for (const entry of files) {
+            if (
+                entry.isFile &&
+                DragAndDropFileSystem.is_kicad_file(entry.name)
+            ) {
+                const file = await DragAndDropFileSystem.load(entry);
+                file_map.set(entry.fullPath, file);
             }
         }
 
-        if (file_entry == null) {
-            throw new Error(`File ${name} not found!`);
-        }
+        // TODO: more than one kicad_pro loaded???
 
+        // deduce the common base directory
+        const lcp = DragAndDropFileSystem.lcp(Array.from(file_map.keys()));
+
+        // get base directory only
+        const prefix = lcp.slice(0, lcp.lastIndexOf("/") + 1);
+
+        return new DragAndDropFileSystem(
+            new Map([...file_map].map(([p, f]) => [p.slice(prefix.length), f])),
+        );
+    }
+
+    private static lcp(str: string[]): string {
+        const beg = str[0] ?? "";
+        return str.reduce((common, path) => {
+            let i = 0;
+
+            while (
+                i < common.length &&
+                i < path.length &&
+                common[i] === path[i]
+            ) {
+                i += 1;
+            }
+
+            return common.slice(0, i);
+        }, beg);
+    }
+
+    private static async load(entry: FileSystemFileEntry): Promise<File> {
         return await new Promise((resolve, reject) => {
-            file_entry!.file(resolve, reject);
+            entry.file(resolve, reject);
         });
     }
 
-    async download(name: string) {
-        initiate_download(await this.get(name));
+    private static async walk(items: FileSystemEntry[]) {
+        const files: FileSystemFileEntry[] = [];
+
+        while (items.length > 0) {
+            const item = items.pop()!;
+            if (item.isFile) {
+                files.push(item as FileSystemFileEntry);
+            } else if (item.isDirectory) {
+                const reader = (
+                    item as FileSystemDirectoryEntry
+                ).createReader();
+
+                await new Promise((resolve, reject) => {
+                    reader.readEntries((entries) => {
+                        for (const entry of entries) {
+                            if (entry.isFile) {
+                                files.push(entry as FileSystemFileEntry);
+                            } else if (entry.isDirectory) {
+                                items.push(entry);
+                            }
+                        }
+                        resolve(true);
+                    }, reject);
+                });
+            }
+        }
+
+        return files;
     }
 }
 
 /**
  * Virtual file system for local files
  */
-export class LocalFileSystem implements IFileSystem {
-    constructor(private files: File[]) {}
-
-    *list() {
-        for (const entry of this.files) {
-            yield entry.name;
-        }
-    }
-
-    async has(name: string): Promise<boolean> {
-        return this.files.find((f) => f.name == name) !== undefined;
-    }
-
-    async get(name: string): Promise<File> {
-        const file = this.files.find((f) => f.name == name);
-        if (file) {
-            return file;
-        } else {
-            throw new Error(`File ${name} not found`);
-        }
-    }
-
-    async download(name: string) {
-        initiate_download(await this.get(name));
+export class LocalFileSystem extends LocalFileSystemBase {
+    constructor(files: File[]) {
+        super(new Map(files.map((f) => [f.name, f])));
     }
 }

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -8,43 +8,85 @@ import { initiate_download } from "../../base/dom/download";
 import { basename } from "../../base/paths";
 
 /**
- * Virtual file system abstract class.
+ * Virtual file system interface.
  *
  * This is the interface used by <kc-kicanvas-shell> to find and load files.
  * It's implemented using Drag and Drop and GitHub to provide a common interface
  * for interacting and loading files.
  */
-export abstract class VirtualFileSystem {
-    public abstract list(): Generator<string>;
-    public abstract get(name: string): Promise<File>;
-    public abstract has(name: string): Promise<boolean>;
-    public abstract download(name: string): Promise<void>;
+export interface IFileSystem {
+    /**
+     * List all files in the file system
+     */
+    list(): Generator<string>;
 
-    public *list_matches(r: RegExp) {
-        for (const filename of this.list()) {
-            if (filename.match(r)) {
-                yield filename;
-            }
+    /**
+     * Get a file from the file system
+     */
+    get(name: string): Promise<File>;
+
+    /**
+     * Return true if current file list has `name`
+     */
+    has(name: string): Promise<boolean>;
+
+    /**
+     * Download a file from the file system. This is used by the "Download" button
+     */
+    download(name: string): Promise<void>;
+}
+
+/**
+ * Merge two virtual file systems into one
+ */
+export class MergedFileSystem implements IFileSystem {
+    private fs_list: IFileSystem[];
+
+    constructor(fs: (IFileSystem | null)[]) {
+        this.fs_list = fs.filter((f) => f !== null);
+    }
+
+    *list() {
+        for (const fs of this.fs_list) {
+            yield* fs.list();
         }
     }
 
-    public *list_ext(ext: string) {
-        if (!ext.startsWith(".")) {
-            ext = `.${ext}`;
-        }
-
-        for (const filename of this.list()) {
-            if (filename.endsWith(ext)) {
-                yield filename;
+    async has(name: string): Promise<boolean> {
+        for (const fs of this.fs_list) {
+            if (await fs.has(name)) {
+                return true;
             }
         }
+
+        return false;
+    }
+
+    async get(name: string): Promise<File> {
+        for (const fs of this.fs_list) {
+            if (await fs.has(name)) {
+                return await fs.get(name);
+            }
+        }
+
+        throw new Error(`File ${name} not found`);
+    }
+
+    async download(name: string) {
+        for (const fs of this.fs_list) {
+            if (await fs.has(name)) {
+                return await fs.download(name);
+            }
+        }
+
+        throw new Error(`File ${name} not found`);
     }
 }
 
 /**
  * Virtual file system for URLs via Fetch
  */
-export class FetchFileSystem extends VirtualFileSystem {
+export class FetchFileSystem implements IFileSystem {
     private urls: Map<string, URL> = new Map();
     private resolver!: (name: string) => URL;
 
@@ -72,8 +114,6 @@ export class FetchFileSystem extends VirtualFileSystem {
         urls: (string | URL)[],
         resolve_file: ((name: string) => URL) | null = null,
     ) {
-        super();
-
         this.resolver = resolve_file ?? this.#default_resolver;
 
         for (const item of urls) {
@@ -81,15 +121,15 @@ export class FetchFileSystem extends VirtualFileSystem {
         }
     }
 
-    public override *list() {
+    *list() {
         yield* this.urls.keys();
     }
 
-    public override async has(name: string) {
+    async has(name: string) {
         return Promise.resolve(this.urls.has(name));
     }
 
-    public override async get(name: string): Promise<File> {
+    async get(name: string): Promise<File> {
         const url = this.#resolve(name);
 
         if (!url) {
@@ -110,7 +150,7 @@ export class FetchFileSystem extends VirtualFileSystem {
         return new File([blob], name);
     }
 
-    public async download(name: string) {
+    async download(name: string) {
         initiate_download(await this.get(name));
     }
 }
@@ -118,10 +158,8 @@ export class FetchFileSystem extends VirtualFileSystem {
 /**
  * Virtual file system for HTML drag and drop (DataTransfer)
  */
-export class DragAndDropFileSystem extends VirtualFileSystem {
-    constructor(private items: FileSystemFileEntry[]) {
-        super();
-    }
+export class DragAndDropFileSystem implements IFileSystem {
+    constructor(private items: FileSystemFileEntry[]) {}
 
     static async fromDataTransfer(dt: DataTransfer) {
         let items: FileSystemEntry[] = [];
@@ -160,13 +198,13 @@ export class DragAndDropFileSystem extends VirtualFileSystem {
         return new DragAndDropFileSystem(items as FileSystemFileEntry[]);
     }
 
-    public override *list() {
+    *list() {
         for (const entry of this.items) {
             yield entry.name;
         }
     }
 
-    public override async has(name: string): Promise<boolean> {
+    async has(name: string): Promise<boolean> {
         for (const entry of this.items) {
             if (entry.name == name) {
                 return true;
@@ -175,7 +213,7 @@ export class DragAndDropFileSystem extends VirtualFileSystem {
         return false;
     }
 
-    public override async get(name: string): Promise<File> {
+    async get(name: string): Promise<File> {
         let file_entry: FileSystemFileEntry | null = null;
         for (const entry of this.items) {
             if (entry.name == name) {
@@ -193,7 +231,7 @@ export class DragAndDropFileSystem extends VirtualFileSystem {
         });
     }
 
-    public async download(name: string) {
+    async download(name: string) {
         initiate_download(await this.get(name));
     }
 }
@@ -201,22 +239,20 @@ export class DragAndDropFileSystem extends VirtualFileSystem {
 /**
  * Virtual file system for local files
  */
-export class LocalFileSystem extends VirtualFileSystem {
-    constructor(private files: File[]) {
-        super();
-    }
+export class LocalFileSystem implements IFileSystem {
+    constructor(private files: File[]) {}
 
-    override *list() {
+    *list() {
         for (const entry of this.files) {
             yield entry.name;
         }
     }
 
-    override async has(name: string): Promise<boolean> {
+    async has(name: string): Promise<boolean> {
         return this.files.find((f) => f.name == name) !== undefined;
     }
 
-    override async get(name: string): Promise<File> {
+    async get(name: string): Promise<File> {
         const file = this.files.find((f) => f.name == name);
         if (file) {
             return file;
@@ -225,55 +261,7 @@ export class LocalFileSystem extends VirtualFileSystem {
         }
     }
 
-    override async download(name: string) {
+    async download(name: string) {
         initiate_download(await this.get(name));
-    }
-}
-
-/**
- * Merge two virtual file systems into one
- */
-export class MergedFileSystem extends VirtualFileSystem {
-    private fs_list: VirtualFileSystem[];
-
-    constructor(fs: (VirtualFileSystem | null)[]) {
-        super();
-        this.fs_list = fs.filter((f) => f !== null);
-    }
-
-    override *list() {
-        for (const fs of this.fs_list) {
-            yield* fs.list();
-        }
-    }
-
-    override async has(name: string): Promise<boolean> {
-        for (const fs of this.fs_list) {
-            if (await fs.has(name)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    override async get(name: string): Promise<File> {
-        for (const fs of this.fs_list) {
-            if (await fs.has(name)) {
-                return await fs.get(name);
-            }
-        }
-
-        throw new Error(`File ${name} not found`);
-    }
-
-    override async download(name: string) {
-        for (const fs of this.fs_list) {
-            if (await fs.has(name)) {
-                return await fs.download(name);
-            }
-        }
-
-        throw new Error(`File ${name} not found`);
     }
 }

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -5,7 +5,13 @@
 */
 
 import { initiate_download } from "../../base/dom/download";
-import { basename, dirname, extension } from "../../base/paths";
+import {
+    based_on,
+    basename,
+    dirname,
+    extension,
+    normalize_join,
+} from "../../base/paths";
 
 /**
  * Virtual file system interface.
@@ -34,9 +40,17 @@ export interface IFileSystem {
 /**
  * File entry, directory or file
  */
-export interface FileEntry {
-    name: string;
+export class FileEntry {
+    path: string;
     type: "file" | "directory";
+}
+
+/**
+ * File entry, additional type for mark visited items
+ */
+class FileEntryCache {
+    path: string;
+    type: "file" | "directory" | "visited-directory";
 }
 
 /**
@@ -51,10 +65,10 @@ export abstract class FileSystemBase implements IFileSystem {
     //     + qwq2.kicad_sch
     // stored as
     // root.kicad_pcb -> { name: "root.kicad_pcb", type: "file" }
-    // subdir -> { name: "subdir", type: "directory" }   <-- optional
+    // subdir -> { name: "subdir", type: "directory" }
     // subdir/qwq1.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
     // subdir/qwq2.kicad_sch -> { name: "subdir/qwq1.kicad_sch", type: "file" }
-    private entries: Map<string, FileEntry>;
+    private entries: Map<string, FileEntryCache>;
 
     constructor(entries: Map<string, FileEntry> = new Map()) {
         this.entries = entries;
@@ -82,8 +96,16 @@ export abstract class FileSystemBase implements IFileSystem {
     }
 
     async has(name: string) {
-        // load entries on current directory
+        if (this.entries.has(name)) {
+            return true;
+        }
+
         const dir = dirname(name);
+        if (!this.entries.has(dir)) {
+            return false;
+        }
+
+        // load entries on current directory
         await this.walk(dir);
 
         // check if the file exists and is a file
@@ -105,34 +127,22 @@ export abstract class FileSystemBase implements IFileSystem {
     }
 
     /**
-     * Walk through directories to find file entry,
-     * and update entries cache.
+     * Walk through directories and update `this.entries`
      */
     private async walk(dir: string): Promise<void> {
-        const queue: string[] = [dir];
+        if (this.entries.get(dir)?.type === "visited-directory") {
+            // visited directory, skip it.
+            return;
+        }
 
-        while (queue.length > 0) {
-            const dir = queue.shift()!;
+        const entries = await this.enumrate(dir);
+        this.entries.set(dir, { path: dir, type: "visited-directory" });
 
-            if (this.entries.has(dir)) {
+        for (const it of entries) {
+            if (it.type === "file" && !FileSystemBase.is_kicad_file(it.path)) {
                 continue;
             }
-
-            const entries = await this.enumrate(dir);
-            this.entries.set(dir, { name: dir, type: "directory" });
-
-            for (const entry of entries) {
-                if (entry.name.startsWith(dir) && entry.type === "directory") {
-                    // walking into subdirectory
-                    queue.push(entry.name);
-                }
-
-                // cache the result
-                const full_path =
-                    dir.length === 0 ? entry.name : `${dir}/${entry.name}`;
-                const abs_entry = { name: full_path, type: entry.type };
-                this.entries.set(full_path, abs_entry);
-            }
+            this.entries.set(it.path, it);
         }
     }
 
@@ -227,7 +237,7 @@ export class LocalFileSystemBase extends FileSystemBase {
         const result = new Map<string, FileEntry>();
 
         for (const path of files.keys()) {
-            result.set(path, { name: path, type: "file" });
+            result.set(path, { path: path, type: "file" });
         }
 
         return result;
@@ -296,8 +306,8 @@ export class FetchFileSystem extends FileSystemBase {
     }
 
     async enumrate(base_dir: string): Promise<FileEntry[]> {
-        return Array.from(this.urls.keys()).map((name) => ({
-            name,
+        return Array.from(this.urls.keys()).map((path) => ({
+            path,
             type: "file",
         }));
     }
@@ -330,7 +340,7 @@ export class DragAndDropFileSystem extends LocalFileSystemBase {
                 DragAndDropFileSystem.is_kicad_file(entry.name)
             ) {
                 const file = await DragAndDropFileSystem.load(entry);
-                file_map.set(entry.fullPath, file);
+                file_map.set(normalize_join(entry.fullPath), file);
             }
         }
 
@@ -338,13 +348,11 @@ export class DragAndDropFileSystem extends LocalFileSystemBase {
 
         // deduce the common base directory
         const lcp = DragAndDropFileSystem.lcp(Array.from(file_map.keys()));
-
-        // get base directory only
-        const prefix = lcp.slice(0, lcp.lastIndexOf("/") + 1);
-
-        return new DragAndDropFileSystem(
-            new Map([...file_map].map(([p, f]) => [p.slice(prefix.length), f])),
+        const res = new Map(
+            [...file_map].map(([p, f]) => [based_on(lcp, p), f]),
         );
+
+        return new DragAndDropFileSystem(res);
     }
 
     private static lcp(str: string[]): string {

--- a/src/kicanvas/services/vfs.ts
+++ b/src/kicanvas/services/vfs.ts
@@ -131,7 +131,7 @@ export abstract class FileSystemBase implements IFileSystem {
             return;
         }
 
-        const entries = await this.enumrate(dir);
+        const entries = await this.enumerate(dir);
         this.entries.set(dir, { path: dir, type: "visited-directory" });
 
         for (const it of entries) {
@@ -150,7 +150,7 @@ export abstract class FileSystemBase implements IFileSystem {
     /**
      * Enumerate files at `base_dir`. (default: empty)
      */
-    protected abstract enumrate(base_dir: string): Promise<FileEntry[]>;
+    protected abstract enumerate(base_dir: string): Promise<FileEntry[]>;
 }
 
 /**
@@ -224,7 +224,7 @@ export class LocalFileSystemBase extends FileSystemBase {
         return file;
     }
 
-    async enumrate(base_dir: string): Promise<FileEntry[]> {
+    async enumerate(base_dir: string): Promise<FileEntry[]> {
         // All files are already provided by the constructor.
         return [];
     }
@@ -301,7 +301,7 @@ export class FetchFileSystem extends FileSystemBase {
         return new File([blob], path);
     }
 
-    async enumrate(base_dir: string): Promise<FileEntry[]> {
+    async enumerate(base_dir: string): Promise<FileEntry[]> {
         return Array.from(this.urls.keys()).map((path) => ({
             path,
             type: "file",


### PR DESCRIPTION
Many issues (#119, #186) report loading problems when a file references other files located in subdirectories of the repo. Consider the following directory structure

```plaintext
+ root.kicad_sch
+ sub
  + sub1.kicad_sch
  + sub2.kicad_sch
```

which schematic hierarchy is

```plaintext
+ root.kicad_sch
  + sub1.kicad_sch
  + sub2.kicad_sch
```

This currently causes an error because the existing VFS is not designed to handle tree-like directory structures. This PR refactors the VFS to support tree-structured files while maintaining backward compatibility with the older implementation. It currently refactors both `GitHubVFS` and `DragAndDropVFS`.

**How it works**

The idea behind the refactoring is

1. Maintain a tree-structured list `entries` in `FileSystemBase`, which preserves the original file system hierarchy.
2. The `has` function returns true if a file exists in entries.
3. The `get` function loads and returns the corresponding File object.

To simplify the implementation, a new `FileSystemBase` abstract class is introduced. It implements all methods required by `IFileSystem` (referred to as `VirtualFileSystem` in commit 2890714705df9378fb09cc89c0776582da21cc96). Two abstract methods are provided for constructing the file tree:

* `load_file`: loads a file from a specific path
* `enumerate`: lists the items in the current directory

Furthermore, to reduce the rate of API requests, it does not recursively list all files. Instead, it lists them on demand based on the directory requested by `has`. The repositories referenced in these issues have been verified to work correctly.

* https://github.com/TT-392/playstation_adapter_pcb
* https://github.com/TT-392/RP2040-base-example
* https://github.com/Vincent-Dalstra/ESP_bare_chip_test_board/tree/a5cf98b5a4ff008193808d2139580ce6fd54707c

If these changes are accepted, we can proceed to implement recursive support for CodeBerg as well.

**Known limits**

The `has` function does not currently attempt to load directories with more than two levels of nesting.

```
+ root.kicad_sch
+ sub1
  + sub2
    + sub.kicad_sch
```

On the initial enumeration, `entries` contains only the root-level items:

```
root.kicad_sch
sub1
```

When `has('sub1/sub2/sub.kicad_sch')` is subsequently called, it returns false because the contents of `sub1` have not yet been enumerated.