### PR TITLE
fix: file loading fails when path contains URL-encoded characters

### DIFF
--- a/src/base/paths.ts
+++ b/src/base/paths.ts
@@ -18,8 +18,12 @@ export function basename(path: string | URL) {
     return path.split("/").at(-1)!;
 }
 
-export function extension(path: string) {
-    return path.split(".").at(-1) ?? "";
+export function extension(path: string): string {
+    const res = path.split(".");
+    if (res.length <= 1) {
+        return "";
+    }
+    return res.at(-1)!;
 }
 
 /**

--- a/src/kicanvas/services/codeberg-vfs.ts
+++ b/src/kicanvas/services/codeberg-vfs.ts
@@ -65,7 +65,8 @@ export class CodebergFileSystem extends FileSystemBase {
                 it.type === "file" &&
                 CodebergFileSystem.is_kicad_file(it.name)
             ) {
-                const file_path = based_on(base_dir, it.path);
+                const path = decodeURI(it.path);
+                const file_path = based_on(base_dir, path);
 
                 this.download_urls.set(file_path, new URL(it.git_url));
 
@@ -74,9 +75,12 @@ export class CodebergFileSystem extends FileSystemBase {
                     path: file_path,
                 });
             } else if (it.type === "dir") {
+                const path = decodeURI(it.path);
+                const dir_path = based_on(base_dir, path);
+
                 result.push({
                     type: "directory",
-                    path: based_on(base_dir, it.path),
+                    path: dir_path,
                 });
             }
         }

--- a/src/kicanvas/services/codeberg.ts
+++ b/src/kicanvas/services/codeberg.ts
@@ -41,7 +41,7 @@ export class Codeberg {
             return null;
         }
 
-        const path_parts = url.pathname.split("/");
+        const path_parts = url.pathname.split("/").map((s) => decodeURI(s));
 
         if (path_parts.length < 3) {
             return null;

--- a/src/kicanvas/services/github-vfs.ts
+++ b/src/kicanvas/services/github-vfs.ts
@@ -73,7 +73,8 @@ export class GitHubFileSystem extends FileSystemBase {
         const result: FileEntry[] = [];
         for (const it of contents) {
             if (it.type === "file" && GitHubFileSystem.is_kicad_file(it.name)) {
-                const file_path = based_on(base_dir, it.path);
+                const path = decodeURI(it.path);
+                const file_path = based_on(base_dir, path);
 
                 this.download_urls.set(file_path, new URL(it.download_url));
 
@@ -82,9 +83,12 @@ export class GitHubFileSystem extends FileSystemBase {
                     path: file_path,
                 });
             } else if (it.type === "dir") {
+                const path = decodeURI(it.path);
+                const dir_path = based_on(base_dir, path);
+
                 result.push({
                     type: "directory",
-                    path: based_on(base_dir, it.path),
+                    path: dir_path,
                 });
             }
         }
@@ -110,12 +114,15 @@ export class GitHubFileSystem extends FileSystemBase {
         // If it's one file just load one file.
         let single_file = false;
         if (info.type === "blob") {
-            if (["kicad_sch", "kicad_pcb"].includes(extension(info.path!))) {
+            const ext_name = extension(info.path!);
+            if (["kicad_sch", "kicad_pcb"].includes(ext_name)) {
                 single_file = true;
             } else {
                 // Link to non-kicad file, try using the containing directory.
                 info.type = "tree";
-                info.path = dirname(info.path!);
+                if (ext_name.length !== 0) {
+                    info.path = dirname(info.path!);
+                }
             }
         }
 

--- a/src/kicanvas/services/github.ts
+++ b/src/kicanvas/services/github.ts
@@ -55,7 +55,7 @@ export class GitHub {
             return null;
         }
 
-        const path_parts = url.pathname.split("/");
+        const path_parts = url.pathname.split("/").map((s) => decodeURI(s));
 
         if (path_parts.length < 3) {
             return null;


### PR DESCRIPTION
Fix #191 