### PR TITLE
Honor explicit schematic wire and label colors

### DIFF
--- a/src/viewers/schematic/painter.ts
+++ b/src/viewers/schematic/painter.ts
@@ -158,9 +158,11 @@ class WirePainter extends SchematicItemPainter {
     }
 
     paint(layer: ViewLayer, w: schematic_items.Wire) {
-        this.gfx.line(
-            new Polyline(w.pts, this.gfx.state.stroke_width, this.theme.wire),
-        );
+        // KiCad uses a zero-alpha stroke color for the default wire color.
+        // Preserve the theme in that case, but honor explicitly colored wires.
+        const color = w.stroke?.color?.a ? w.stroke.color : this.theme.wire;
+
+        this.gfx.line(new Polyline(w.pts, this.gfx.state.stroke_width, color));
     }
 }
 
@@ -641,7 +643,7 @@ class SchematicSheetPainter extends SchematicItemPainter {
 }
 
 export class SchematicPainter extends BaseSchematicPainter {
-    override theme: SchematicTheme;
+    declare theme: SchematicTheme;
 
     constructor(gfx: Renderer, layers: LayerSet, theme: SchematicTheme) {
         super(gfx, layers, theme);

--- a/src/viewers/schematic/painters/base.ts
+++ b/src/viewers/schematic/painters/base.ts
@@ -13,13 +13,13 @@ import type { SchematicPainter } from "../painter";
 import type { SymbolTransform } from "./symbol";
 
 export abstract class BaseSchematicPainter extends DocumentPainter {
-    override theme: SchematicTheme;
+    declare theme: SchematicTheme;
     current_symbol?: schematic_items.SchematicSymbol;
     current_symbol_transform?: SymbolTransform;
 }
 
 export abstract class SchematicItemPainter extends ItemPainter {
-    override view_painter: SchematicPainter;
+    declare view_painter: SchematicPainter;
 
     override get theme(): SchematicTheme {
         return this.view_painter.theme;

--- a/src/viewers/schematic/painters/label.ts
+++ b/src/viewers/schematic/painters/label.ts
@@ -57,8 +57,13 @@ export class LabelPainter extends SchematicItemPainter {
         );
 
         this.gfx.state.push();
-        this.gfx.state.stroke = this.color;
-        this.gfx.state.fill = this.color;
+        // KiCad uses a zero-alpha font color to select the label's theme
+        // color. Preserve that fallback, but honor explicitly colored labels.
+        const color = l.effects.font.color.a
+            ? l.effects.font.color
+            : this.color;
+        this.gfx.state.stroke = color;
+        this.gfx.state.fill = color;
 
         StrokeFont.default().draw(
             this.gfx,

--- a/test/sch/painters/label-color.test.ts
+++ b/test/sch/painters/label-color.test.ts
@@ -1,0 +1,89 @@
+/*
+    Copyright (c) 2026 Alethea Katherine Flowers.
+    Published under the standard MIT License.
+    Full text available at: https://opensource.org/licenses/MIT
+*/
+
+import { assert } from "chai";
+import { Color } from "../../../src/base/color";
+import { At, Effects } from "../../../src/kicad/common";
+import {
+    GlobalLabel,
+    HierarchicalLabel,
+    Label,
+    NetLabel,
+} from "../../../src/kicad/schematic";
+import witch_hazel from "../../../src/kicanvas/themes/witch-hazel";
+import {
+    NullRenderLayer,
+    NullRenderer,
+} from "../../../src/graphics/null-renderer";
+import { LayerNames, LayerSet } from "../../../src/viewers/schematic/layers";
+import { SchematicPainter } from "../../../src/viewers/schematic/painter";
+
+type LabelConstructor = new (...args: any[]) => Label;
+
+function paint_label(
+    LabelType: LabelConstructor,
+    color: Color,
+): NullRenderLayer {
+    const renderer = new NullRenderer();
+    renderer.state.stroke_width = 0.1524;
+
+    const layers = new LayerSet(witch_hazel.schematic);
+    const painter = new SchematicPainter(
+        renderer,
+        layers,
+        witch_hazel.schematic,
+    );
+    const effects = new Effects();
+    effects.font.color = color;
+    const label = Object.assign(Object.create(LabelType.prototype), {
+        text: "LABEL",
+        at: new At(),
+        effects,
+        shape: "passive",
+    }) as Label;
+    const layer = layers.by_name(LayerNames.label)!;
+
+    layer.items.push(label);
+    painter.paint_layer(layer);
+
+    return layer.graphics as NullRenderLayer;
+}
+
+suite("sch.painters.LabelPainter() label colors", function () {
+    const label_types = [NetLabel, GlobalLabel, HierarchicalLabel];
+
+    for (const LabelType of label_types) {
+        test(`${LabelType.name} uses an explicit font color`, function () {
+            const color = new Color(1, 15 / 255, 31 / 255, 1);
+            const shapes = paint_label(LabelType, color).shapes;
+
+            assert.isNotEmpty(shapes);
+            for (const shape of shapes) {
+                assert.deepEqual(shape.color, color);
+            }
+        });
+    }
+
+    test("uses theme colors for KiCad's zero-alpha default", function () {
+        const expected_colors = [
+            witch_hazel.schematic.label_local,
+            witch_hazel.schematic.label_global,
+            witch_hazel.schematic.label_hier,
+        ];
+
+        for (const [index, LabelType] of label_types.entries()) {
+            const shapes = paint_label(
+                LabelType,
+                Color.transparent_black,
+            ).shapes;
+
+            assert.isNotEmpty(shapes);
+            for (const shape of shapes) {
+                assert.deepEqual(shape.color, expected_colors[index]);
+            }
+        }
+    });
+});

--- a/test/sch/painters/wire.test.ts
+++ b/test/sch/painters/wire.test.ts
@@ -1,0 +1,73 @@
+/*
+    Copyright (c) 2026 Alethea Katherine Flowers.
+    Published under the standard MIT License.
+    Full text available at: https://opensource.org/licenses/MIT
+*/
+
+import { assert } from "chai";
+import { Color } from "../../../src/base/color";
+import { Vec2 } from "../../../src/base/math";
+import {
+    NullRenderLayer,
+    NullRenderer,
+} from "../../../src/graphics/null-renderer";
+import { Polyline } from "../../../src/graphics/shapes";
+import { Stroke } from "../../../src/kicad/common";
+import { Wire } from "../../../src/kicad/schematic";
+import witch_hazel from "../../../src/kicanvas/themes/witch-hazel";
+import { LayerNames, LayerSet } from "../../../src/viewers/schematic/layers";
+import { SchematicPainter } from "../../../src/viewers/schematic/painter";
+
+function paint_wire(color?: Color, with_stroke = true): Polyline {
+    const renderer = new NullRenderer();
+    renderer.state.stroke_width = 0.1524;
+
+    const layers = new LayerSet(witch_hazel.schematic);
+    const painter = new SchematicPainter(
+        renderer,
+        layers,
+        witch_hazel.schematic,
+    );
+    const wire = Object.assign(Object.create(Wire.prototype), {
+        pts: [new Vec2(0, 0), new Vec2(10, 0)],
+    }) as Wire;
+
+    if (with_stroke) {
+        wire.stroke = {
+            ...Stroke.default_value(),
+            ...(color ? { color } : {}),
+        };
+    }
+    const layer = layers.by_name(LayerNames.wire)!;
+
+    layer.items.push(wire);
+    painter.paint_layer(layer);
+
+    return (layer.graphics as NullRenderLayer).shapes[0] as Polyline;
+}
+
+suite("sch.painters.WirePainter()", function () {
+    test("uses an explicit KiCad stroke color", function () {
+        const color = new Color(1, 15 / 255, 31 / 255, 1);
+
+        assert.deepEqual(paint_wire(color).color, color);
+    });
+
+    test("uses the theme color for KiCad's zero-alpha default", function () {
+        assert.deepEqual(
+            paint_wire(Color.transparent_black).color,
+            witch_hazel.schematic.wire,
+        );
+    });
+
+    test("uses the theme color when a legacy stroke omits color", function () {
+        assert.deepEqual(paint_wire().color, witch_hazel.schematic.wire);
+    });
+
+    test("uses the theme color when a legacy wire omits stroke", function () {
+        assert.deepEqual(
+            paint_wire(undefined, false).color,
+            witch_hazel.schematic.wire,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

KiCanvas currently draws schematic wires and local/global/hierarchical labels in the theme colors even when the KiCad file specifies an explicit color.

This change respects wire `stroke.color` and label `effects.font.color`, including the label outline. Missing or zero-alpha wire colors continue to use the theme, as do unspecified label colors. This also handles older wire records without a color or stroke entry.

The `declare` changes preserve TypeScript-only field narrowing without initializing those fields over their inherited values in the browser test transform.

## Validation

- Eight focused Chrome regression tests pass, covering explicit wire and label colors, default colors, and older wire records.
- `npm run build` passes, including the TypeScript check, with no warnings or errors.
- The renderer was also checked locally against real schematics and 547 saved construction snapshots. Wire and label colors were visually checked in the self-hosted viewer and video output.

```sh
npm test -- --files test/sch/painters/wire.test.ts --files test/sch/painters/label-color.test.ts
npm run build
```

## Scope

This handles explicit colors stored in schematic items, not project-level netclass color resolution. Directive labels and symbol property fields already support explicit colors and are unchanged. No site-specific styling, font hosting, or embed changes are included.
